### PR TITLE
refactor!: Endre "enhet" i header til å kun vises dersom den sendes inn

### DIFF
--- a/packages/familie-header/header.stories.tsx
+++ b/packages/familie-header/header.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Brukerinfo, Header, Infokort, PopoverItem, Søk } from './src';
 import { KvinneIkon } from '@navikt/familie-ikoner';
+import './headerstories.less';
 
 export default {
     component: Header,
@@ -52,7 +53,7 @@ export const header = () => {
     };
 
     return (
-        <>
+        <div className={'headerstory'}>
             <Header
                 tittel={'tittel'}
                 brukerinfo={saksbehandler}
@@ -72,6 +73,6 @@ export const header = () => {
                     }
                 </Søk>
             </Header>
-        </>
+        </div>
     );
 };

--- a/packages/familie-header/headerstories.less
+++ b/packages/familie-header/headerstories.less
@@ -1,0 +1,3 @@
+.headerstory {
+    font-family: 'Source Sans Pro', Arial, Helvetica, sans-serif;
+}

--- a/packages/familie-header/src/header/Header.tsx
+++ b/packages/familie-header/src/header/Header.tsx
@@ -30,19 +30,21 @@ export interface HeaderProps {
 
 interface BrukerProps {
     navn: string;
+    enhet?: string;
     popoverItems?: PopoverItem[];
 }
 interface LenkePopoverProps {
     lenker?: PopoverItem[];
 }
 
-export const Bruker = ({ navn, popoverItems }: BrukerProps) => {
+export const Bruker = ({ navn, enhet, popoverItems }: BrukerProps) => {
     const [anker, settAnker] = React.useState<HTMLElement | undefined>(undefined);
 
     return (
         <div>
             <UserPanel
                 name={navn}
+                unit={enhet && `Enhet: ${enhet}`}
                 onClick={(e) => {
                     settAnker(anker === undefined ? e.currentTarget : undefined);
                 }}
@@ -106,7 +108,7 @@ export const Header = ({ tittel, children, brukerinfo, tittelHref = '/', brukerP
                 {children}
                 <LenkePopover lenker={eksterneLenker} />
                 <div className='avdeler' />
-                <Bruker navn={brukerinfo.navn} popoverItems={brukerPopoverItems} />
+                <Bruker navn={brukerinfo.navn} enhet={brukerinfo.enhet} popoverItems={brukerPopoverItems} />
             </div>
         </div>
     );

--- a/packages/familie-header/src/header/Header.tsx
+++ b/packages/familie-header/src/header/Header.tsx
@@ -10,7 +10,7 @@ import { IkonSystem } from '../icons';
 
 export interface Brukerinfo {
     navn: string;
-    enhet: string;
+    enhet?: string;
 }
 
 export interface PopoverItem {
@@ -30,21 +30,19 @@ export interface HeaderProps {
 
 interface BrukerProps {
     navn: string;
-    enhet: string;
     popoverItems?: PopoverItem[];
 }
 interface LenkePopoverProps {
     lenker?: PopoverItem[];
 }
 
-export const Bruker = ({ navn, enhet, popoverItems }: BrukerProps) => {
+export const Bruker = ({ navn, popoverItems }: BrukerProps) => {
     const [anker, settAnker] = React.useState<HTMLElement | undefined>(undefined);
 
     return (
         <div>
             <UserPanel
                 name={navn}
-                unit={`Enhet: ${enhet}`}
                 onClick={(e) => {
                     settAnker(anker === undefined ? e.currentTarget : undefined);
                 }}
@@ -103,13 +101,12 @@ export const Header = ({ tittel, children, brukerinfo, tittelHref = '/', brukerP
                 <h1 className='tittel'>
                     <a href={tittelHref}>{tittel}</a>
                 </h1>
-                <div className='avdeler' />
             </div>
             <div className='rad'>
                 {children}
                 <LenkePopover lenker={eksterneLenker} />
                 <div className='avdeler' />
-                <Bruker {...brukerinfo} popoverItems={brukerPopoverItems} />
+                <Bruker navn={brukerinfo.navn} popoverItems={brukerPopoverItems} />
             </div>
         </div>
     );


### PR DESCRIPTION
Etter avtale med Tone (EF) og Gunn (BA) ble vi enige om at Enhet ikke er en nødvendig opplysning å ha med i headeren, men saksbehandlere ønsker fremdeles å ha den inntil videre i BA. 