### PR TITLE
feat(Skjult label): en skjult label som leses av skjermleser men som …

### DIFF
--- a/packages/familie-form-elements/src/index.ts
+++ b/packages/familie-form-elements/src/index.ts
@@ -8,3 +8,4 @@ export * from './select';
 export * from './familie-react-select';
 export * from './textarea';
 export * from './textareacontrolled';
+export * from './skjultLabel';

--- a/packages/familie-form-elements/src/skjultLabel/SkjultLabel.tsx
+++ b/packages/familie-form-elements/src/skjultLabel/SkjultLabel.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Label } from 'nav-frontend-skjema';
+
+const StyledLabel = styled(Label)`
+    position: absolute;
+    clip: rect(0 0 0 0);
+`;
+
+export interface SkjultLabelProps {
+    htmlFor: string;
+}
+
+const SkjultLabel: React.FC<SkjultLabelProps> = ({ htmlFor, children }) => (
+    <StyledLabel htmlFor={htmlFor}>{children}</StyledLabel>
+);
+
+export default SkjultLabel;

--- a/packages/familie-form-elements/src/skjultLabel/index.ts
+++ b/packages/familie-form-elements/src/skjultLabel/index.ts
@@ -1,0 +1,1 @@
+export * from './SkjultLabel';

--- a/packages/familie-form-elements/src/skjultLabel/skjultLabel.stories.tsx
+++ b/packages/familie-form-elements/src/skjultLabel/skjultLabel.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import SkjultLabel from './SkjultLabel';
+import { Input } from 'nav-frontend-skjema';
+import { Normaltekst } from 'nav-frontend-typografi';
+
+export default {
+    component: SkjultLabel,
+    parameters: {
+        componentSubtitle: 'En skjult label som kun vises i htmldom-strukturen for skjermlesere.',
+    },
+    title: 'Komponenter/Form-elementer/SkjultLabel',
+};
+
+export const SkjultLabelStory: React.FC = () => (
+    <>
+        <Normaltekst>
+            I noen tilfeller passer det ikke alltid i layouten med en tilhørende label som er synlig
+            til hvert form-element. Likevel er det viktig at koden har en label, slik at de som
+            bruker skjermleser får opp form-elements i riktig kontekst. Denne komponenten legger på
+            en skjult label, som du vil se hvis du åpner inspect.
+        </Normaltekst>
+        <SkjultLabel htmlFor="input" />
+        <Input id="input" />
+    </>
+);

--- a/packages/familie-form-elements/src/skjultLabel/skjultLabel.stories.tsx
+++ b/packages/familie-form-elements/src/skjultLabel/skjultLabel.stories.tsx
@@ -11,15 +11,17 @@ export default {
     title: 'Komponenter/Form-elementer/SkjultLabel',
 };
 
-export const SkjultLabelStory: React.FC = () => (
-    <>
-        <Normaltekst>
-            I noen tilfeller passer det ikke alltid i layouten med en tilhørende label som er synlig
-            til hvert form-element. Likevel er det viktig at koden har en label, slik at de som
-            bruker skjermleser får opp form-elements i riktig kontekst. Denne komponenten legger på
-            en skjult label, som du vil se hvis du åpner inspect.
-        </Normaltekst>
-        <SkjultLabel htmlFor="input" />
-        <Input id="input" />
-    </>
-);
+export const SkjultLabelStory: React.FC = () => {
+    return (
+        <>
+            <Normaltekst>
+                I noen tilfeller passer det ikke alltid i layouten med en tilhørende label som er
+                synlig til hvert form-element. Likevel er det viktig at koden har en label, slik at
+                de som bruker skjermleser får opp form-elements i riktig kontekst. Denne komponenten
+                legger på en skjult label, som du vil se hvis du åpner inspect.
+            </Normaltekst>
+            <SkjultLabel htmlFor="input" />
+            <Input id="input" />
+        </>
+    );
+};


### PR DESCRIPTION
Eksponerer ut skjult label til en komponent som kan brukes av alle. Den ligger per nå også i søk, bytter til å bruke felleskomponenten når pakken er oppdatert. 

affects: @navikt/familie-form-elements