### PR TITLE
(chore) Fjern unødvendig import av css som skaper konflikt med jest

### DIFF
--- a/packages/familie-form-elements/src/datovelger/FamilieDatovelger.tsx
+++ b/packages/familie-form-elements/src/datovelger/FamilieDatovelger.tsx
@@ -1,4 +1,3 @@
-import 'nav-datovelger/lib/styles/datepicker';
 import { Datepicker as NavDatovelger } from 'nav-datovelger';
 
 import { Label } from 'nav-frontend-skjema';


### PR DESCRIPTION
Datepickeren importerer uansett den less-filen internt så vi skaper bare krøll ved å importere den her.