### PR TITLE
fix(Flagg for nullstilling ved avhengighetsendring): send med et flag…

### DIFF
--- a/packages/familie-skjema/src/felt.ts
+++ b/packages/familie-skjema/src/felt.ts
@@ -30,6 +30,7 @@ export interface FeltConfig<Verdi> {
     skalFeltetVises?: (avhengigheter: Avhengigheter) => boolean;
     valideringsfunksjon?: ValiderFelt<Verdi>;
     verdi: Verdi;
+    nullstillVedAvhengighetEndring?: boolean;
 }
 
 export function useFelt<Verdi = string>({
@@ -38,6 +39,7 @@ export function useFelt<Verdi = string>({
     skalFeltetVises,
     valideringsfunksjon,
     verdi,
+    nullstillVedAvhengighetEndring = true,
 }: FeltConfig<Verdi>): Felt<Verdi> {
     const [id] = useState(feltId ? feltId : genererId());
     const initialFeltState = {
@@ -88,9 +90,11 @@ export function useFelt<Verdi = string>({
      */
     useEffect(() => {
         if (skalFeltetVises) {
-            if (feltState.valideringsstatus !== Valideringsstatus.IKKE_VALIDERT) {
+
+            if (nullstillVedAvhengighetEndring && feltState.valideringsstatus !== Valideringsstatus.IKKE_VALIDERT) {
                 nullstill();
             }
+
             settErSynlig(skalFeltetVises(avhengigheter));
         } else {
             validerOgSettFelt();


### PR DESCRIPTION
… om at feltet skal nullstilles


I søknaden så ønsker vi ikke at feltet skal nullstilles når avhengigheter endrer seg. Derfor legges det til en prop som man kan sende med. Den er satt be default slik at den ikke brekker eksisterende bruk av skjemahook.


affects: @navikt/familie-skjema