### PR TITLE
fix(familie-form-elements): skjul tom feil-kontainer fra radiopanelgruppe

### DIFF
--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/familie-form-elements",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "main": "dist/index.js",
   "author": "NAV",
   "license": "MIT",

--- a/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
+++ b/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
@@ -17,24 +17,12 @@ export interface JaNeiSpørsmålProps {
 }
 
 const StyledRadioPanelGruppe = styled(RadioPanelGruppe)`
-    div {
-        display: grid;
-        grid-template-columns: 1fr;
-        grid-template-rows: 1fr;
-        grid-template: 'ja' 'nei';
-        grid-gap: 1rem;
-
-        label:first-child {
-            grid-area: ja;
+    && {
+        div {
+            label:not(:last-child) {
+                margin-bottom: 1rem;
+            }
         }
-
-        label:last-child {
-            grid-area: nei;
-        }
-    }
-
-    div:empty {
-        display: none; // Nav sin radiopanelgruppe rendrer feil-container selv om feil er tom, så vi skjuler den for å fikse spacing
     }
 `;
 

--- a/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
+++ b/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
@@ -32,6 +32,10 @@ const StyledRadioPanelGruppe = styled(RadioPanelGruppe)`
             grid-area: nei;
         }
     }
+
+    div:empty {
+        display: none; // Nav sin radiopanelgruppe rendrer feil-container selv om feil er tom, så vi skjuler den for å fikse spacing
+    }
 `;
 
 const Capitalized = styled.span`

--- a/packages/familie-form-elements/src/ja-nei-spørsmål/jaNeiSpørsmål.stories.tsx
+++ b/packages/familie-form-elements/src/ja-nei-spørsmål/jaNeiSpørsmål.stories.tsx
@@ -16,7 +16,8 @@ export default {
 };
 
 const DivMedBredde = styled.div<{bredde: string}>`
-  width: ${props => props.bredde};
+    width: ${props => props.bredde};
+    margin-bottom: 3rem;
 `
 
 export const FamilieJaNeiSpørsmålStory: React.FC = () => {
@@ -40,6 +41,15 @@ export const FamilieJaNeiSpørsmålStory: React.FC = () => {
                     onChange={value => {
                         alert(value === ESvar.NEI ? 'So sad' : 'Yayy, hurra!');
                     }}
+                />
+            </DivMedBredde>
+            <DivMedBredde bredde={bredde.toString(10) + '%'}>
+                <JaNeiSpørsmål
+                    onChange={() => {}}
+                    legend={"Denne har feilmelding"}
+                    name={'felt.medfeil'}
+                    labelTekstForJaNei={{ja: "Yes sir", nei: "Nåneidu"}}
+                    feil={"Dette var ikke bra"}
                 />
             </DivMedBredde>
             <div>

--- a/packages/familie-sprakvelger/package.json
+++ b/packages/familie-sprakvelger/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.7",
+    "version": "2.0.8",
     "name": "@navikt/familie-sprakvelger",
     "author": "NAV",
     "homepage": "https://github.com/navikt/familie-felles-frontend#readme",


### PR DESCRIPTION
RadioPanelGruppe fra nav-frontend-skjema rendrer feil-kontainer uansett om feil er tom eller ikke.
Skjul alle tomme divs i gruppen for å unngå rar spacing.