### PR TITLE
fix(Send intiellVerdi som prop): sett en initiell verdi til jaNeiSpm

### DIFF
--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/familie-form-elements",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "main": "dist/index.js",
   "author": "NAV",
   "license": "MIT",

--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/familie-form-elements",
-  "version": "2.2.8",
+  "version": "2.2.10",
   "main": "dist/index.js",
   "author": "NAV",
   "license": "MIT",

--- a/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
+++ b/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
@@ -13,6 +13,7 @@ export interface JaNeiSpørsmålProps {
     legend: ReactNode;
     name: string;
     labelTekstForJaNei: LabelTekstForJaNei;
+    initiellVerdi?: ESvar | undefined;
     feil?: ReactNode;
 }
 
@@ -44,8 +45,9 @@ export const JaNeiSpørsmål: React.FC<JaNeiSpørsmålProps> = ({
     onChange,
     labelTekstForJaNei,
     feil,
+    initiellVerdi
 }) => {
-    const [checked, setChecked] = useState<ESvar | undefined>();
+    const [checked, setChecked] = useState<ESvar | undefined>(initiellVerdi);
 
     return (
         <StyledRadioPanelGruppe


### PR DESCRIPTION
Trenger at jaNeiSpm kan ha en annen initiell verdi enn undefined. F.eks. at ja er valgt når den rendres. Dette for å kunne navigere tilbake i søknadsdialog og få opp det man har fylt inn.