### PR TITLE
Validerer felt når feltet initialiseres.

### DIFF
--- a/packages/familie-skjema/src/felt.ts
+++ b/packages/familie-skjema/src/felt.ts
@@ -58,8 +58,8 @@ export function useFelt<Verdi = string>({
         settFeltState(initialFeltState);
     };
 
-    const validerOgSettFelt = (verdi: Verdi = feltState.verdi) => {
-        const validertFelt = feltState.valider(
+    const validerOgSettFelt = (verdi: Verdi = feltState.verdi): FeltState<Verdi> => {
+        const validertFelt: FeltState<Verdi> = feltState.valider(
             {
                 ...feltState,
                 verdi,
@@ -70,6 +70,8 @@ export function useFelt<Verdi = string>({
         if (!deepEqual(feltState, validertFelt)) {
             settFeltState(validertFelt);
         }
+
+        return validertFelt;
     };
 
     const hentAvhengighetArray = () => {
@@ -83,12 +85,6 @@ export function useFelt<Verdi = string>({
               }, [])
             : [];
     };
-
-    useEffect(() => {
-        if (feltState.valideringsstatus === Valideringsstatus.IKKE_VALIDERT) {
-            validerOgSettFelt();
-        }
-    }, [feltState.valideringsstatus]);
 
     /**
      * Basert på avhengighetene til feltet håndterer vi vis/skjul

--- a/packages/familie-skjema/src/felt.ts
+++ b/packages/familie-skjema/src/felt.ts
@@ -37,14 +37,14 @@ export function useFelt<Verdi = string>({
     avhengigheter = {},
     feltId,
     skalFeltetVises,
-    valideringsfunksjon,
+    valideringsfunksjon = defaultValidator,
     verdi,
     nullstillVedAvhengighetEndring = true,
 }: FeltConfig<Verdi>): Felt<Verdi> {
     const [id] = useState(feltId ? feltId : genererId());
     const initialFeltState = {
         feilmelding: '',
-        valider: valideringsfunksjon ? valideringsfunksjon : defaultValidator,
+        valider: valideringsfunksjon,
         valideringsstatus: Valideringsstatus.IKKE_VALIDERT,
         verdi,
     };
@@ -84,14 +84,22 @@ export function useFelt<Verdi = string>({
             : [];
     };
 
+    useEffect(() => {
+        if (feltState.valideringsstatus === Valideringsstatus.IKKE_VALIDERT) {
+            validerOgSettFelt();
+        }
+    }, [feltState.valideringsstatus]);
+
     /**
      * Basert på avhengighetene til feltet håndterer vi vis/skjul
      * og nullstilling på feltet.
      */
     useEffect(() => {
         if (skalFeltetVises) {
-
-            if (nullstillVedAvhengighetEndring && feltState.valideringsstatus !== Valideringsstatus.IKKE_VALIDERT) {
+            if (
+                nullstillVedAvhengighetEndring &&
+                feltState.valideringsstatus !== Valideringsstatus.IKKE_VALIDERT
+            ) {
                 nullstill();
             }
 

--- a/packages/familie-skjema/src/skjema.ts
+++ b/packages/familie-skjema/src/skjema.ts
@@ -28,17 +28,26 @@ export const useSkjema = <Felter, SkjemaRespons>({
     };
 
     const validerAlleSynligeFelter = (): FeltState<unknown>[] => {
-        return alleSynligeFelter()
-            .filter(
-                felt =>
-                    (felt as Felt<unknown>).valideringsstatus === Valideringsstatus.IKKE_VALIDERT,
-            )
-            .map(felt => {
-                const unknownFelt = felt as Felt<unknown>;
-                return unknownFelt.validerOgSettFelt(unknownFelt.verdi, {
-                    felter,
-                });
-            });
+        const synligeFelter: Felt<unknown>[] = alleSynligeFelter().map(
+            felt => felt as Felt<unknown>,
+        );
+
+        return [
+            ...synligeFelter
+                .filter(
+                    (unknownFelt: Felt<unknown>) =>
+                        unknownFelt.valideringsstatus === Valideringsstatus.IKKE_VALIDERT,
+                )
+                .map((unknownFelt: Felt<unknown>) => {
+                    return unknownFelt.validerOgSettFelt(unknownFelt.verdi, {
+                        felter,
+                    });
+                }),
+            ...synligeFelter.filter(
+                (unknownFelt: Felt<unknown>) =>
+                    unknownFelt.valideringsstatus !== Valideringsstatus.IKKE_VALIDERT,
+            ),
+        ];
     };
 
     const valideringErOk = () => {

--- a/packages/familie-skjema/src/typer.ts
+++ b/packages/familie-skjema/src/typer.ts
@@ -68,7 +68,10 @@ export type ValiderFelt<Verdi> = (
     avhengigheter?: Avhengigheter,
 ) => FeltState<Verdi>;
 
-export type ValiderOgSettFelt<Verdi> = (verdi: Verdi, avhengigheter?: Avhengigheter) => void;
+export type ValiderOgSettFelt<Verdi> = (
+    verdi: Verdi,
+    avhengigheter?: Avhengigheter,
+) => FeltState<Verdi>;
 
 export const defaultValidator = <Verdi>(felt: FeltState<Verdi>) => ({
     ...felt,


### PR DESCRIPTION
Usikker på hvilke konsekvenser dette får, så vær litt ekstra oppmerksom. Hypotesen er at skjema uansett gir et "visFeilmeldinger" flagg og selv om feltene da initielt blir "feil" så viser man ikke i UI feilmeldinger før "visFeilmeldinger" er true. 

For tilfeller hvor man bruker useFelt alene så bør man uansett håndtere når man skal vise feilmeldinger eksplisitt.