### PR TITLE
fix(Stor eller liten forbokstav): stor forbokstav på kun først ordet

### DIFF
--- a/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
+++ b/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
@@ -25,7 +25,9 @@ const StyledRadioPanelGruppe = styled(RadioPanelGruppe)`
 `;
 
 const Capitalized = styled.span`
+  ::first-letter{
     text-transform: capitalize;
+  }
 `;
 
 export const JaNeiSpørsmål: React.FC<JaNeiSpørsmålProps> = ({


### PR DESCRIPTION
Fjern at alle ord får stor forbokstav i labels til ja-nei-spørsmål