### PR TITLE
fix(språkvelger): gi svger aria-hidden og fjern focusable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,8 +5,7 @@
         "plugin:jsx-a11y/recommended",
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
-        "prettier",
-        "prettier/@typescript-eslint"
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/packages/familie-sprakvelger/src/Sprakvelger.tsx
+++ b/packages/familie-sprakvelger/src/Sprakvelger.tsx
@@ -36,12 +36,12 @@ const StyledNormalTekst = styled(Normaltekst)`
 `;
 
 const StyledCollapse = styled(Collapse)`
-  z-index: -1;
-`
+    z-index: -1;
+`;
 
 const StyledExpand = styled(Expand)`
-  z-index: -1;
-`
+    z-index: -1;
+`;
 
 export const Sprakvelger: React.FC<{ støttedeSprak: LocaleType[] }> = ({ støttedeSprak }) => {
     const [valgtLocale, setValgtLocale] = useSprakContext();
@@ -63,9 +63,13 @@ export const Sprakvelger: React.FC<{ støttedeSprak: LocaleType[] }> = ({ støtt
                 {hentSprakvelgerLabelTekst(valgtLocale)}
             </SkjultLabel>
             <StyledButton id="språkvelger" value={valgtLocale}>
-                <Globe role="img" />
+                <Globe role="img" focusable={false} aria-hidden={true} />
                 <StyledNormalTekst>{sprakTittel[valgtLocale as LocaleType]}</StyledNormalTekst>
-                {erÅpen ? <StyledCollapse role="img" /> : <StyledExpand role="img" />}
+                {erÅpen ? (
+                    <StyledCollapse role="img" focusable={false} aria-hidden={true} />
+                ) : (
+                    <StyledExpand role="img" focusable={false} aria-hidden={true} />
+                )}
             </StyledButton>
             <SpråkSelectMenu valgtLocale={valgtLocale} støttedeSprak={støttedeSprak} />
         </StyledWrapper>


### PR DESCRIPTION
affects: @navikt/familie-sprakvelger

Har også fikset eslintrc-fila

Ref https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute, rent dekorative ikoner kan settes til `aria--hidden="true"`. 
Alternativet er å lage tre nye utility-functions for å få tak i aria label for globe, ned-chevron og opp-chevron på alle støtta språk slik som vi har gjort med dropdown label.
Alternativ to er å bruke intl-objektet nå som vi har intl som peer dependency og gi appen ansvaret for disse tekstene.