### PR TITLE
Gjør det mulig å sende med metadata til logging, sånn att man kan få …

### DIFF
--- a/packages/familie-logging/src/logging.ts
+++ b/packages/familie-logging/src/logging.ts
@@ -9,6 +9,8 @@ export enum LOG_LEVEL {
     DEBUG = 0,
 }
 
+export type Meta = Record<string, unknown>;
+
 const secureLogPath = () =>
     fs.existsSync('/secure-logs/') ? '/secure-logs/secure.log' : './secure.log';
 
@@ -24,22 +26,22 @@ export const secureLogger = winston.createLogger({
     transports: [new winston.transports.File({ filename: secureLogPath(), maxsize: 5242880 })],
 });
 
-export const logDebug = (message: string) => {
-    stdoutLogger.debug(message);
+export const logDebug = (message: string, meta: Meta = {}) => {
+    stdoutLogger.debug(message, meta);
 };
 
-export const logInfo = (message: string) => {
-    stdoutLogger.info(message);
+export const logInfo = (message: string, meta: Meta = {}) => {
+    stdoutLogger.info(message, meta);
 };
 
-export const logWarn = (message: string) => {
-    stdoutLogger.warn(message);
+export const logWarn = (message: string, meta: Meta = {}) => {
+    stdoutLogger.warn(message, meta);
 };
 
-export const logError = (message: string, err?: Error) => {
-    stdoutLogger.error(message, err && { message: `: ${err?.message || err}` });
+export const logError = (message: string, err?: Error, meta: Meta = {}) => {
+    stdoutLogger.error(message, { ...meta, ...(err && { message: `: ${err?.message || err}` }) });
 };
 
-export const logSecure = (message: string) => {
-    secureLogger.info(message);
+export const logSecure = (message: string, meta: Meta = {}) => {
+    secureLogger.info(message, meta);
 };


### PR DESCRIPTION
…med x_callId for spåring

Ønsker å gjøre det mulig å logge callId når man kaller på logRequest, sånn att det blir enklere å finne ut hvilken request som årsaket logRequest-loggingen.

Hele endringen: https://github.com/navikt/familie-felles-frontend/compare/log-request-callId?expand=1