### PR TITLE
fix(sprakvelger): fjern 170px bredde på språkvelger

### DIFF
--- a/packages/familie-sprakvelger/sprakvelger.stories.tsx
+++ b/packages/familie-sprakvelger/sprakvelger.stories.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Sprakvelger } from './src/Sprakvelger';
-import { LocaleType } from './src/typer';
-import { SprakProvider } from './src/SprakContext';
+import { Sprakvelger, LocaleType, SprakProvider } from './src';
 import { FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
 
 export default {
     component: Sprakvelger,
@@ -25,10 +24,27 @@ const messages = {
 };
 
 export const FamilieSprakvelger: React.FC = () => {
+    const Wrapper = styled.div`
+        display: flex;
+        flex-direction: column;
+        align-items: start;
+    `;
+
+    const StyledSprakvelger = styled(Sprakvelger)`
+        color: green;
+        margin: auto;
+    `;
+
     return (
         <SprakProvider tekster={messages} defaultLocale={LocaleType.en}>
-            <Sprakvelger støttedeSprak={[LocaleType.en, LocaleType.nn, LocaleType.nb]} />
-            <FormattedMessage id={'greeting'} />
+            <Wrapper>
+                <Sprakvelger støttedeSprak={[LocaleType.en, LocaleType.nn, LocaleType.nb]} />
+                <p>
+                    <FormattedMessage id={'greeting'} />
+                </p>
+                <p>Den kan styles om ønskelig</p>
+                <StyledSprakvelger støttedeSprak={[LocaleType.en, LocaleType.nn, LocaleType.nb]} />
+            </Wrapper>
         </SprakProvider>
     );
 };

--- a/packages/familie-sprakvelger/src/Sprakvelger.tsx
+++ b/packages/familie-sprakvelger/src/Sprakvelger.tsx
@@ -11,10 +11,8 @@ import { SkjultLabel } from '@navikt/familie-form-elements';
 import { hentSprakvelgerLabelTekst } from './utils';
 
 const StyledWrapper = styled(Wrapper)`
-    width: 170px;
     position: relative;
     outline: none;
-    margin: auto;
 `;
 
 const StyledButton = styled(Button)`
@@ -43,7 +41,10 @@ const StyledExpand = styled(Expand)`
     z-index: -1;
 `;
 
-export const Sprakvelger: React.FC<{ støttedeSprak: LocaleType[] }> = ({ støttedeSprak }) => {
+export const Sprakvelger: React.FC<{ støttedeSprak: LocaleType[]; className?: string }> = ({
+    støttedeSprak,
+    className,
+}) => {
     const [valgtLocale, setValgtLocale] = useSprakContext();
     const [erÅpen, setErÅpen] = React.useState(false);
 
@@ -58,6 +59,7 @@ export const Sprakvelger: React.FC<{ støttedeSprak: LocaleType[] }> = ({ støtt
         <StyledWrapper
             onSelection={(value: JSX.Element) => handleSelection(value)}
             onMenuToggle={wrapperState => setErÅpen(wrapperState.isOpen)}
+            className={className}
         >
             <SkjultLabel htmlFor="språkvelger">
                 {hentSprakvelgerLabelTekst(valgtLocale)}


### PR DESCRIPTION
affects: @navikt/familie-sprakvelger

Gjort språkvelgeren stylebar og fjernet fixed bredde og margin auto slik at apper kan bruke den som
de vil