### PR TITLE
Forbedre lesevisning på react multiselect

### DIFF
--- a/packages/familie-form-elements/src/familie-react-select/FamilieReactSelect.tsx
+++ b/packages/familie-form-elements/src/familie-react-select/FamilieReactSelect.tsx
@@ -20,7 +20,7 @@ const Container = styled.div`
     margin-bottom: 1rem;
 `;
 
-const navSelectStyles = (feil?: ReactNode): StylesConfig => ({
+const navSelectStyles = (feil?: ReactNode, erLesevisning?: boolean): StylesConfig => ({
     control: (provided, state) => ({
         ...provided,
         border:
@@ -41,14 +41,18 @@ const navSelectStyles = (feil?: ReactNode): StylesConfig => ({
         ...provided,
         color: navFarger.navGra60,
     }),
-    dropdownIndicator: provided => ({
+    dropdownIndicator: provided => (
+        erLesevisning ? { display: 'none' }
+        : {
         ...provided,
         color: 'initial',
         ':hover': {
             color: 'initial',
         },
     }),
-    clearIndicator: provided => ({
+    clearIndicator: provided => (
+        erLesevisning ? { display: 'none' }
+        : {
         ...provided,
         color: navFarger.navGra60,
         ':hover': {
@@ -60,7 +64,9 @@ const navSelectStyles = (feil?: ReactNode): StylesConfig => ({
         backgroundColor: navFarger.navBlaLighten80,
         maxWidth: '18rem',
     }),
-    multiValueRemove: provided => ({
+    multiValueRemove: provided => (
+        erLesevisning ? { display: 'none' }
+        : {
         ...provided,
         ':hover': {
             backgroundColor: navFarger.navBla,
@@ -96,11 +102,12 @@ export const FamilieReactSelect: React.FC<IProps> = ({
 
     const hentSelectProps = () => ({
         styles: {
-            ...navSelectStyles(feil),
+            ...navSelectStyles(feil, erLesevisning),
             ...propSelectStyles,
         },
         id: id,
         isDisabled: erLesevisning,
+        isClearable: !erLesevisning,
         value,
         placeholder: 'Velg',
         noOptionsMessage: () => 'Ingen valg',


### PR DESCRIPTION
Fjerner visning av knapper/endringikoner under lesevisning

Uten lesevisning 
![Skjermbilde 2021-06-15 kl  16 10 08](https://user-images.githubusercontent.com/5719550/122068924-13ee5480-cdf5-11eb-8129-37fb8feebafe.png)

Med lesevisning **før**
![Skjermbilde 2021-06-15 kl  16 21 24](https://user-images.githubusercontent.com/5719550/122069813-c3c3c200-cdf5-11eb-9b4c-622d262a51fc.png)

Med lesevisning **etter**
![Skjermbilde 2021-06-15 kl  16 10 14](https://user-images.githubusercontent.com/5719550/122068929-1486eb00-cdf5-11eb-8db5-cceb7e0e8c4d.png)

Eksempel fra ba-sak **etter**
![Skjermbilde 2021-06-15 kl  15 55 27](https://user-images.githubusercontent.com/5719550/122068982-1d77bc80-cdf5-11eb-9fbc-760cff209d38.png)
