### PR TITLE
fix(familie-sprakvelger): fjern hardkoda locale slik at man kan passe…

### DIFF
--- a/packages/familie-form-elements/src/datovelger/FamilieDatovelger.tsx
+++ b/packages/familie-form-elements/src/datovelger/FamilieDatovelger.tsx
@@ -62,7 +62,6 @@ export const FamilieDatovelger: React.FC<IDatovelgerProps & DatepickerProps> = (
                         name: id,
                         placeholder,
                     }}
-                    locale={'nb'}
                     value={valgtDato}
                     onChange={onChange}
                 />


### PR DESCRIPTION
… det inn som prop

affects: @navikt/familie-form-elements

Bokmål er allerede default valg i nav-datovelger, fjern hardkoda verdi her