### PR TITLE
chore(sprakvelger|form-elements): bump datovelgerversjon, typer for språkcontext

### DIFF
--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/familie-form-elements",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "main": "dist/index.js",
     "author": "NAV",
     "license": "MIT",

--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -20,7 +20,7 @@
         "@types/react-select": "^3.0.28",
         "classnames": "^2.2.6",
         "dayjs": "^1.10.4",
-        "nav-datovelger": "^11.0.0",
+        "nav-datovelger": "^12.1.2",
         "nav-frontend-knapper": "^2.1.2",
         "nav-frontend-knapper-style": "^1.1.2",
         "nav-frontend-lenker": "^1.1.1",

--- a/packages/familie-sprakvelger/src/SprakContext.tsx
+++ b/packages/familie-sprakvelger/src/SprakContext.tsx
@@ -7,7 +7,10 @@ interface SprakProviderProps {
     defaultLocale: LocaleType;
 }
 
-const SprakContext = createContext<any>(['', () => {}]);
+const SprakContext = createContext<[
+    LocaleType,
+    React.Dispatch<React.SetStateAction<LocaleType>>
+]>([LocaleType.nb, () => { return; }]);
 const useSprakContext = () => useContext(SprakContext);
 
 const SprakProvider: React.FC<SprakProviderProps> = ({ tekster, defaultLocale, children }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9363,12 +9363,19 @@ focus-lock@^0.8.1:
   dependencies:
     tslib "^1.9.3"
 
-focus-trap-react@^8.1.0, focus-trap-react@^8.5.0:
+focus-trap-react@^8.1.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.5.0.tgz#c4d08609ed1da0976b856519fd2c97760524474c"
   integrity sha512-YnQ3PtoszlXqHQQIYCnnTbWsXa6daEACXg9KkFvv357PkJUVp347G9L+e9WJwj2KgSIX+pTDcZFx+f7azo8dhw==
   dependencies:
     focus-trap "^6.4.0"
+
+focus-trap-react@^8.6.0:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.7.1.tgz#a9e4dc866db5e6794bdb751cad9ddc8989598ec5"
+  integrity sha512-1bCCtdZXSzYVrMEcvHfHq+706OSM5r3iZsBFXy9zbnf3+5dyCFiEVWix7Sf6jUaOgshjpyDvZHiBhSlcsO9k3A==
+  dependencies:
+    focus-trap "^6.6.1"
 
 focus-trap@^6.4.0:
   version "6.4.0"
@@ -9376,6 +9383,13 @@ focus-trap@^6.4.0:
   integrity sha512-RpH291GjfNhy1ek+Iwe00oCaqJN0sBaB+S/v7BpCIldf39IslPI7657nOZ6HwgoEHpjCmUJoAY+Mfgrm0rohvQ==
   dependencies:
     tabbable "^5.2.0"
+
+focus-trap@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.6.1.tgz#761ce2c82ddd72beeb049e968bc8414e25b704aa"
+  integrity sha512-x9BWuAeF5UrfWuYKJ3jYrjcVYSYptS9CqtxH5IH7lPlZrMsaugKeAa0HtoZSBZe5DmeTMx2m0qY464ZMzqarzw==
+  dependencies:
+    tabbable "^5.2.1"
 
 follow-redirects@^1.10.0:
   version "1.13.0"
@@ -13046,12 +13060,12 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-nav-datovelger@^11.0.0:
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/nav-datovelger/-/nav-datovelger-11.1.2.tgz#a93eb06c8cfc39471c5d6ef7c29212e45ad75031"
-  integrity sha512-Zk2vU7hnSLGtfcogSsdi4cCpedIIDpzZncIsXzHCXJvs1u3sqx/CCcTMHONMKYVDuYLtw58dROaPcO3PuXrwDw==
+nav-datovelger@^12.1.2:
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/nav-datovelger/-/nav-datovelger-12.1.2.tgz#cdf1b702526eed29a7203831cd4809161479615d"
+  integrity sha512-Lh0fTX4rc2FeQbdL3y5kI2YsMkl1IFRwLUUMrgTQO/gFelw6PvW47wxV1ZJlcAZAJjc/w/M4w86dKRrh80aYhw==
   dependencies:
-    focus-trap-react "^8.5.0"
+    focus-trap-react "^8.6.0"
 
 nav-datovelger@^8.0.0:
   version "8.0.4"
@@ -17437,6 +17451,11 @@ tabbable@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
   integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
+
+tabbable@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
+  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
 
 table@^6.0.4:
   version "6.0.7"


### PR DESCRIPTION
affects: @navikt/familie-form-elements, @navikt/familie-sprakvelger

Datovelger med måneder på riktig språk i dropdown
Typer på språkcontext slik at useSpråkContext forteller hva den returnerer