### PR TITLE
Header linker, lagt til mulighet for override av onClick

### DIFF
--- a/packages/familie-header/src/header/Header.tsx
+++ b/packages/familie-header/src/header/Header.tsx
@@ -19,6 +19,7 @@ export interface PopoverItem {
     name: string;
     href: string;
     isExternal?: boolean;
+    onClick?: (e: React.SyntheticEvent) => void;
 }
 
 export interface HeaderProps {
@@ -64,7 +65,10 @@ export const Bruker = ({ navn, enhet, popoverItems }: BrukerProps) => {
                     tabIndex={-1}
                     utenPil
                 >
-                    <BoxedListWithLinks items={popoverItems} />
+                    <BoxedListWithLinks
+                        items={popoverItems}
+                        onClick={(index, e) => popoverItems[index]?.onClick?.(e)}
+                    />
                 </Popover>
             )}
         </div>
@@ -96,7 +100,10 @@ export const LenkePopover = ({ lenker }: LenkePopoverProps) => {
                     }}
                     tabIndex={-1}
                 >
-                    <BoxedListWithLinks items={lenker || []} />
+                    <BoxedListWithLinks
+                        items={lenker || []}
+                        onClick={(index, e) => lenker[index]?.onClick?.(e)}
+                    />
                 </Popover>
             )}
         </div>

--- a/packages/familie-header/src/søk/FnrInputWrapper.tsx
+++ b/packages/familie-header/src/søk/FnrInputWrapper.tsx
@@ -6,7 +6,7 @@ interface FnrInputWrapperProps extends FnrInputProps {
     acceptSynthNr?: boolean;
 }
 
-//support synthID for FnrInput
+// support synthID for FnrInput
 export const FnrInputWrapper: React.FC<FnrInputWrapperProps> = ({
     id,
     onChange,


### PR DESCRIPTION
Ønsker å kunne linke til personlig side på a-inntekt, med 

```ts
const lagAInntekt = (appEnv: AppEnv, personIdent?: string): PopoverItem => {
    if (!personIdent) {
        return { name: 'A-inntekt', href: appEnv.aInntekt, isExternal: true };
    }

    return {
        name: 'A-inntekt',
        href: '#/a-inntekt',
        onClick: (e: React.SyntheticEvent) => {
            e.preventDefault();
            ...
        },
    };
};
```


Der ... er eks
```ts
preferredAxios
                .get(`${appEnv.aInntekt}/api/v2/redirect/sok/a-inntekt`, {
                    headers: {
                        'Nav-Personident': personIdent,
                    },
                })
                .then((response: AxiosResponse<string>) => {
                    window.open(response.data);
                })
                .catch((error: AxiosError<string>) => {
                    apiLoggFeil(`Henting av redirect-link mot a-inntekt feilet ${error}`);
                    window.open(appEnv.aInntekt);
                });
```