### PR TITLE
feat(Dokumentliste): skal vise logiske vedlegg i dokumentliste

### DIFF
--- a/packages/familie-dokumentliste/dokumentliste.stories.tsx
+++ b/packages/familie-dokumentliste/dokumentliste.stories.tsx
@@ -5,21 +5,22 @@ import { Journalposttype } from '@navikt/familie-typer';
 export default {
     component: Dokumentliste,
     parameters: {
-        componentSubtitle: 'Dokumentliste-komponenten brukes til å vise informasjon om dokumenter fra journalposter.',
+        componentSubtitle:
+            'Dokumentliste-komponenten brukes til å vise informasjon om dokumenter fra journalposter.',
     },
     title: 'Komponenter/Dokumentliste',
     argTypes: {
         dokumenter: {
             description: 'Liste av dokumenter',
-        }
-    }
+        },
+    },
 };
 
 const lastNedDokument = (dokument: DokumentProps): void => {
     // tslint:disable-next-line:no-console
     console.log('Laster ned', dokument);
 };
-const dokumenterForStory = [
+const dokumenterForStory: DokumentProps[] = [
     {
         dokumentinfoId: '12345',
         journalpostId: '23456',
@@ -33,6 +34,10 @@ const dokumenterForStory = [
         tittel: 'Dokument 2',
         journalposttype: Journalposttype.U,
         dato: '2020-12-05',
+        logiskeVedlegg: [
+            { logiskVedleggId: '1', tittel: 'Manuelt skannet innhold 1' },
+            { logiskVedleggId: '2', tittel: 'Manuelt skannet innhold 2' },
+        ],
     },
     {
         dokumentinfoId: '12345',
@@ -46,17 +51,14 @@ const dokumenterForStory = [
 interface Props {
     dokumenter: DokumentProps[];
 }
-export const Dokumentlistekomponent:React.FC<Props> = ({dokumenter = dokumenterForStory, ...args}) => {
-    return (
-        <Dokumentliste
-            dokumenter={dokumenter}
-            onClick={lastNedDokument}
-            {...args}
-        />
-    );
+export const Dokumentlistekomponent: React.FC<Props> = ({
+    dokumenter = dokumenterForStory,
+    ...args
+}) => {
+    return <Dokumentliste dokumenter={dokumenter} onClick={lastNedDokument} {...args} />;
 };
 
 // @ts-ignore
 Dokumentlistekomponent.args = {
-   dokumenter: dokumenterForStory
-}
+    dokumenter: dokumenterForStory,
+};

--- a/packages/familie-dokumentliste/src/LogiskeVedlegg.tsx
+++ b/packages/familie-dokumentliste/src/LogiskeVedlegg.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import * as React from 'react';
+import { ILogiskVedlegg } from '@navikt/familie-typer';
+import { Undertekst } from 'nav-frontend-typografi';
+
+const LogiskVedleggWrapper = styled.ul`
+    grid-area: vedlegg;
+    padding-left: 16px;
+    list-style-type: circle;
+`;
+export const LogiskeVedlegg: React.FC<{ logiskeVedlegg: ILogiskVedlegg[] | undefined }> = ({
+    logiskeVedlegg,
+}) => (
+    <LogiskVedleggWrapper>
+        {logiskeVedlegg &&
+            logiskeVedlegg.map((logiskVedlegg, index) => (
+                <li>
+                    <Undertekst key={logiskVedlegg.tittel + index}>
+                        {logiskVedlegg.tittel}
+                    </Undertekst>
+                </li>
+            ))}
+    </LogiskVedleggWrapper>
+);

--- a/packages/familie-dokumentliste/src/index.tsx
+++ b/packages/familie-dokumentliste/src/index.tsx
@@ -5,7 +5,8 @@ import { Element, Undertekst } from 'nav-frontend-typografi';
 import PilVenstre from '@navikt/familie-ikoner/dist/utils/PilVenstre';
 import PilNed from '@navikt/familie-ikoner/dist/utils/PilNed';
 import PilHøyre from '@navikt/familie-ikoner/dist/utils/PilHøyre';
-import { Journalposttype } from '@navikt/familie-typer';
+import { ILogiskVedlegg, Journalposttype } from '@navikt/familie-typer';
+import { LogiskeVedlegg } from './LogiskeVedlegg';
 
 const StyledDokumentListe = styled.ul`
     padding: 0;
@@ -18,9 +19,10 @@ const StyledKnapp = styled.button`
     display: grid;
     grid-gap: 0 1rem;
     grid-template-columns: minmax(min-content, max-content);
-    grid-template-rows: repeat(2, min-content);
+    grid-template-rows: repeat(3, min-content);
     grid-template-areas:
         'ikon tittel'
+        'ikon vedlegg'
         'ikon dato';
     max-width: 300px;
     background-color: transparent;
@@ -38,6 +40,7 @@ const JournalpostIkon = styled.span`
 `;
 const StyledUndertekst = styled(Undertekst)`
     grid-area: dato;
+    display: flex;
 `;
 
 const StyledDokumentnavn = styled(Element)`
@@ -46,6 +49,7 @@ const StyledDokumentnavn = styled(Element)`
     overflow: hidden;
     color: ${navFarger.navBla};
     grid-area: tittel;
+    display: flex;
 `;
 
 interface JournalpostikonProps {
@@ -72,6 +76,7 @@ export interface DokumentProps {
     journalposttype: Journalposttype;
     dokumentinfoId: string;
     filnavn?: string;
+    logiskeVedlegg?: ILogiskVedlegg[];
 }
 
 export interface DokumentElementProps {
@@ -93,6 +98,7 @@ export const DokumentElement: React.FC<DokumentElementProps> = ({ dokument, onCl
                     <Journalpostikon journalposttype={dokument.journalposttype} />
                 </JournalpostIkon>
                 <StyledDokumentnavn>{dokument.tittel}</StyledDokumentnavn>
+                <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
                 <StyledUndertekst>{dokument.dato}</StyledUndertekst>
             </StyledKnapp>
         </li>


### PR DESCRIPTION
affects: @navikt/familie-dokumentliste

Lister opp logiske vedlegg (innhold fra skannet dokumenter) under dokumentet.

<img width="341" alt="image" src="https://user-images.githubusercontent.com/21220467/156392660-a2be7600-0745-4aa9-aedb-8ebe33227bb4.png">
