### PR TITLE
Slett moment-timezone fra dependencies

### DIFF
--- a/packages/familie-backend/package.json
+++ b/packages/familie-backend/package.json
@@ -44,7 +44,6 @@
     "express-http-proxy": "^1.6.0",
     "express-session": "^1.17.1",
     "https-proxy-agent": "^5.0.0",
-    "moment-timezone": "^0.5.27",
     "openid-client": "^4.7.2",
     "passport": "^0.4.0",
     "prom-client": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14873,18 +14873,6 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment-timezone@^0.5.27:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
-  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
-  dependencies:
-    moment ">= 2.9.0"
-
-"moment@>= 2.9.0":
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
Moment-timezone ser ikke ut til å bli brukt lenger. I tillegg fører den versjonen som var installert til et sikkerhetshull i ba-sak: https://github.com/navikt/familie-ba-sak-frontend/security/dependabot/15.

Sletter derfor hele dependencien. Fint hvis noen med kjennskap til familie-backend tar en titt her, bare for å dobbeltsjekke. Moment-timezone kom opp under unused dependencies (ved å gjøre npx depcheck i familie-backend pakken), men noen ganger er det ikke alltid det stemmer.