### PR TITLE
fix(dokumentliste): venstrejusterer tekst i dokumentlisten

### DIFF
--- a/packages/familie-dokumentliste/dokumentliste.stories.tsx
+++ b/packages/familie-dokumentliste/dokumentliste.stories.tsx
@@ -31,7 +31,7 @@ const dokumenterForStory: DokumentProps[] = [
     {
         dokumentinfoId: '12344',
         journalpostId: '23454',
-        tittel: 'Dokument 2',
+        tittel: 'Et litt lengre navn på et dokument som går over to linjer',
         journalposttype: Journalposttype.U,
         dato: '2020-12-05',
         logiskeVedlegg: [

--- a/packages/familie-dokumentliste/src/LogiskeVedlegg.tsx
+++ b/packages/familie-dokumentliste/src/LogiskeVedlegg.tsx
@@ -3,11 +3,11 @@ import * as React from 'react';
 import { ILogiskVedlegg } from '@navikt/familie-typer';
 import { Detail } from '@navikt/ds-react';
 
-
 const LogiskVedleggWrapper = styled.ul`
     grid-area: vedlegg;
     padding-left: 16px;
     list-style-type: circle;
+    text-align: left;
 `;
 export const LogiskeVedlegg: React.FC<{ logiskeVedlegg: ILogiskVedlegg[] | undefined }> = ({
     logiskeVedlegg,
@@ -16,9 +16,7 @@ export const LogiskeVedlegg: React.FC<{ logiskeVedlegg: ILogiskVedlegg[] | undef
         {logiskeVedlegg &&
             logiskeVedlegg.map((logiskVedlegg, index) => (
                 <li>
-                    <Detail key={logiskVedlegg.tittel + index}>
-                        {logiskVedlegg.tittel}
-                    </Detail>
+                    <Detail key={logiskVedlegg.tittel + index}>{logiskVedlegg.tittel}</Detail>
                 </li>
             ))}
     </LogiskVedleggWrapper>

--- a/packages/familie-dokumentliste/src/index.tsx
+++ b/packages/familie-dokumentliste/src/index.tsx
@@ -50,6 +50,7 @@ const StyledDokumentnavn = styled(Label)`
     color: var(--navds-global-color-blue-500);
     grid-area: tittel;
     display: flex;
+    text-align: left;
 `;
 
 interface JournalpostikonProps {


### PR DESCRIPTION
affects: @navikt/familie-dokumentliste
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9268

Mistet litt venstrejustering ved oppdatering til nytt designsystem (Dette ble tidligere lagt på i ef-sak-frontend).
**Før**
![image](https://user-images.githubusercontent.com/21220467/185102066-2d047e5d-ec5f-44c7-931f-fe4dcfa49e17.png)

**Etter**
![image](https://user-images.githubusercontent.com/21220467/185101729-05fa783f-5307-40f8-93f8-c1a6a2315a30.png)
