### PR TITLE
fix(familie-form-elements): inkluder fjernede avhengigheter som datovelgeren trenger

### DIFF
--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -27,6 +27,10 @@
         "classnames": "^2.3.1",
         "dayjs": "^1.11.3",
         "nav-datovelger": "^12.5.0",
+        "nav-frontend-core": "^6.0.x",
+        "nav-frontend-js-utils": "^1.0.x",
+        "nav-frontend-skjema": "^4.0.x",
+        "nav-frontend-typografi": "^4.0.x",
         "react-select": "^5.4.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3710,7 +3710,7 @@
 
 "@navikt/ds-tokens@^0.9.x":
   version "0.9.8"
-  resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/0.9.8/469390dc1f26a91f5c64792afa8f935d78612f00184a3f26058602f8cbc849da#2f3226abe39844915337395390159235bb9fd1cc"
+  resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/0.9.8/2f3226abe39844915337395390159235bb9fd1cc#2f3226abe39844915337395390159235bb9fd1cc"
   integrity sha512-44I4NS19RU9xQMgIBNZu2kLerhRN4BtnxOP40haqgo7n83XYVaJExSmwtspbnkzB9NUvvECjKkAsFNfZLjRqNQ==
 
 "@nodelib/fs.scandir@2.1.4":
@@ -15049,10 +15049,32 @@ nav-datovelger@^12.5.0:
   dependencies:
     focus-trap-react "^8.6.0"
 
+nav-frontend-core@^6.0.x:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/nav-frontend-core/-/nav-frontend-core-6.0.1.tgz#81feef412890cb84074d329a2e3a8b6bca4ba314"
+  integrity sha512-zFAPRXgmS3Nhu5SyafsTnCFg2/PEbrUF+g1xGo+pKIxGfJgCeLi47gPSe7Kjeh3IwIo0ex3cA7tfbUIWOY65dQ==
+
+nav-frontend-js-utils@^1.0.x:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/nav-frontend-js-utils/-/nav-frontend-js-utils-1.0.20.tgz#fac829adb801d66275ac273255d5102b73d5805e"
+  integrity sha512-rCEbgtLmk/95TJeke3Njgm0lBJuBa0N8p8h5Oqhxjov529UjTT2Vx4XJzjQd7/ApgeCkdc5DB9GW5jGTEFoYTA==
+  dependencies:
+    lodash.throttle "^4.1.1"
+
 nav-frontend-skjema@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/nav-frontend-skjema/-/nav-frontend-skjema-4.0.5.tgz#ad2b569e4aba0ff2eaed69ec3c5fc9c4459ae531"
   integrity sha512-rY/PycRYqBSpUk9rnePAJ9fd+QRBC3vbE8e5d9YKmxKeF5Q73azbb3hoHWjm0CfpeEgRttRDfbIWRFH2SPwvCw==
+
+nav-frontend-skjema@^4.0.x:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/nav-frontend-skjema/-/nav-frontend-skjema-4.0.6.tgz#17714d105e026ad7c079abf586bfa327aed336f7"
+  integrity sha512-lnlrBuab+sX+mOmzPtQXXNEzA/Z7bun4snBcGkl2AfSzw2DF0tXmmf0nQW3c7BRQksX3lZw07E8I7ka/Dxr1ng==
+
+nav-frontend-typografi@^4.0.x:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/nav-frontend-typografi/-/nav-frontend-typografi-4.0.2.tgz#470cc95f4b4ff3a94363dd86eeea45bd9dc6014a"
+  integrity sha512-WUlhb9hXp1Z0CIqULGTYnD7EBPW5dTpBq0qlv+CcjiE4ooqWaRjvhDycj/rR9sjaB4EciF8uViUpIZk4YATqlw==
 
 needle@2.6.0, needle@^2.3.3, needle@^2.5.0:
   version "2.6.0"


### PR DESCRIPTION

affects: @navikt/familie-form-elements

**Ooops** i #540 fjernet jeg avhengigheter som tilsynelatende ikke var i bruk. Det viser seg at de er peerdependencies for datovelgeren. _Litt_ irriterende at alle CI-actions kjørte grønt på PRen når `yarn build` viste seg å ikke kunne kjøre. Tenker det er på sin plass å legge til et steg i PR-action for det, så vi unngår at noe liknende skjer igjen