### PR TITLE
fix(familie-form-elements): legg tilbake enda flere avhengigheter som datovelger trenger

### DIFF
--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -26,11 +26,14 @@
         "@types/react-select": "^5.0.1",
         "classnames": "^2.3.1",
         "dayjs": "^1.11.3",
-        "nav-datovelger": "^12.5.0",
+        "nav-datovelger": "^12.6.0",
         "nav-frontend-core": "^6.0.x",
         "nav-frontend-js-utils": "^1.0.x",
+        "nav-frontend-knapper-style": "^2.1.1",
         "nav-frontend-skjema": "^4.0.x",
+        "nav-frontend-skjema-style": "^3.0.2",
         "nav-frontend-typografi": "^4.0.x",
+        "nav-frontend-typografi-style": "^2.0.1",
         "react-select": "^5.4.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15042,14 +15042,14 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-nav-datovelger@^12.5.0:
-  version "12.5.0"
-  resolved "https://registry.yarnpkg.com/nav-datovelger/-/nav-datovelger-12.5.0.tgz#4ba62549145c29d3f73186f4016acd37bde792ed"
-  integrity sha512-ySekEZCl+6eyEhMFwJ6+KGLcqke+yEOatsCcPFdZzQ8gm3F6lIpcP+WTCjgLtBH8kJysjhQYHVmeLMUDqHZUsg==
+nav-datovelger@^12.6.0:
+  version "12.6.0"
+  resolved "https://registry.yarnpkg.com/nav-datovelger/-/nav-datovelger-12.6.0.tgz#e3b4020429584e71d2d16f5483e67e32fd3298b6"
+  integrity sha512-z7hmVcPSqZAoOX40hG/a7E9QQNZoPjRfL2Qn+ylYIYLv5Nx0lzFVZPHnubzdUFTYBf5SFJ6EGWcv9u6ISn2FDA==
   dependencies:
     focus-trap-react "^8.6.0"
 
-nav-frontend-core@^6.0.x:
+nav-frontend-core@^6.0.1, nav-frontend-core@^6.0.x:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/nav-frontend-core/-/nav-frontend-core-6.0.1.tgz#81feef412890cb84074d329a2e3a8b6bca4ba314"
   integrity sha512-zFAPRXgmS3Nhu5SyafsTnCFg2/PEbrUF+g1xGo+pKIxGfJgCeLi47gPSe7Kjeh3IwIo0ex3cA7tfbUIWOY65dQ==
@@ -15061,6 +15061,16 @@ nav-frontend-js-utils@^1.0.x:
   dependencies:
     lodash.throttle "^4.1.1"
 
+nav-frontend-knapper-style@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/nav-frontend-knapper-style/-/nav-frontend-knapper-style-2.1.2.tgz#692e51f77a15bbb5ca0423aafcea479df5961108"
+  integrity sha512-OOJhbhMhRNsv7qS8iFMFWc03zrSK5l8e3x64UrMGyku6IgO7dmX7DtzUuOR74f9lDOBiwWDk8i/gnx3mX0t5/Q==
+
+nav-frontend-skjema-style@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/nav-frontend-skjema-style/-/nav-frontend-skjema-style-3.0.3.tgz#ecb3ca762b7c04d603a3772f5dcf910c6715a7f5"
+  integrity sha512-YCSQ+4M3tdg9wC1jgwABvi2CFQw5DD/I49LGuYGy1v8CPqZeuaoRIzbJr91kpdWxfyXaZM/eZdhTwPOsJlCkew==
+
 nav-frontend-skjema@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/nav-frontend-skjema/-/nav-frontend-skjema-4.0.5.tgz#ad2b569e4aba0ff2eaed69ec3c5fc9c4459ae531"
@@ -15070,6 +15080,13 @@ nav-frontend-skjema@^4.0.x:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/nav-frontend-skjema/-/nav-frontend-skjema-4.0.6.tgz#17714d105e026ad7c079abf586bfa327aed336f7"
   integrity sha512-lnlrBuab+sX+mOmzPtQXXNEzA/Z7bun4snBcGkl2AfSzw2DF0tXmmf0nQW3c7BRQksX3lZw07E8I7ka/Dxr1ng==
+
+nav-frontend-typografi-style@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/nav-frontend-typografi-style/-/nav-frontend-typografi-style-2.0.2.tgz#03d39354b9c5af483a76672bb98761c432579496"
+  integrity sha512-/vKawzUV29g2iDxAEBA535l0WdUGKcCF4dzoqAKdcTv6M8Y7ypJiV1U7d2PieRKgCINH7bINoBAKEOXQw1Kl2Q==
+  dependencies:
+    nav-frontend-core "^6.0.1"
 
 nav-frontend-typografi@^4.0.x:
   version "4.0.2"


### PR DESCRIPTION
Nå med enda flere avhengigheter som `nav-datovelger` ikke opplyser å være avhengig av 🥲  ...nå kjører `yarn build`, `yarn storybook` osv grønt hos meg.

affects: @navikt/familie-form-elements