### PR TITLE
feat(familie-form-elements): støtt ref forwarding i FamilieInput

### DIFF
--- a/packages/familie-form-elements/src/input/FamilieInput.tsx
+++ b/packages/familie-form-elements/src/input/FamilieInput.tsx
@@ -1,5 +1,5 @@
 import { BodyShort, TextField, TextFieldProps } from '@navikt/ds-react';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { FamilieLesefelt } from '../lesefelt';
 
 export interface IFamilieInputProps extends TextFieldProps {
@@ -7,16 +7,19 @@ export interface IFamilieInputProps extends TextFieldProps {
     tekstLesevisning?: string;
 }
 
-export const FamilieInput: React.FC<IFamilieInputProps> = ({
-    size,
-    className,
-    children,
-    erLesevisning = false,
-    label,
-    tekstLesevisning = 'Ingen opplysninger oppgitt.',
-    value,
-    ...props
-}) => {
+export const FamilieInput: React.ForwardRefExoticComponent<
+    IFamilieInputProps & React.RefAttributes<HTMLInputElement>
+> = forwardRef<HTMLInputElement, IFamilieInputProps>((props, ref) => {
+    const {
+        size,
+        className,
+        children,
+        erLesevisning = false,
+        label,
+        tekstLesevisning = 'Ingen opplysninger oppgitt.',
+        value,
+        ...restProps
+    } = props;
     return erLesevisning ? (
         value === '' ? (
             <BodyShort className={className} children={tekstLesevisning} />
@@ -24,8 +27,15 @@ export const FamilieInput: React.FC<IFamilieInputProps> = ({
             <FamilieLesefelt size={size} className={className} label={label} verdi={value} />
         )
     ) : (
-        <TextField size={size} className={className} label={label} value={value} {...props}>
+        <TextField
+            size={size}
+            className={className}
+            label={label}
+            value={value}
+            ref={ref}
+            {...restProps}
+        >
             {children}
         </TextField>
     );
-};
+});

--- a/packages/familie-form-elements/src/input/input.stories.tsx
+++ b/packages/familie-form-elements/src/input/input.stories.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@navikt/ds-react';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import '../../stories.less';
 import { FamilieInput } from './FamilieInput';
 
@@ -14,6 +14,12 @@ export default {
 export const FamilieInputStory: React.FC = ({ ...args }) => {
     const [lesevisning, settLesevisning] = useState(false);
     const [inputVerdi, settInputVerdi] = useState('Den satte verdien');
+    const [tallVerdi, settTallVerdi] = useState(30);
+    const eksempelReferanse = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        console.log('Nå har referansen knyttet seg til elementet:', eksempelReferanse.current);
+    }, [eksempelReferanse.current]);
 
     const onClickToggleKnapp = () => {
         if (lesevisning) {
@@ -36,6 +42,14 @@ export const FamilieInputStory: React.FC = ({ ...args }) => {
                     erLesevisning={lesevisning}
                     onChange={e => settInputVerdi(e.target.value)}
                     value={inputVerdi}
+                    {...args}
+                />
+                <FamilieInput
+                    label="Eksempel på inputfelt med tallverdi"
+                    erLesevisning={lesevisning}
+                    onChange={e => settTallVerdi(Number(e.target.value))}
+                    value={tallVerdi}
+                    ref={eksempelReferanse}
                     {...args}
                 />
             </div>


### PR DESCRIPTION
affects: @navikt/familie-form-elements

I det gamle designbiblioteket kunne refs sendes inn som et custom prop og dermed omgå at React behandler `ref`-propen som noe helt eget. Nå som designsystemet forventer å få inn `ref` satt slik React egentlig definerer det, må vi derfor støtte videresending av ref med `React.forwardRef`. Se docs her hvis du vil lese mer: https://reactjs.org/docs/forwarding-refs.html

...eeeegentlig skulle jeg verifisere at FamilieInput aksepterer number som type på value, så jeg har lagt til et eksempel i storybook på en FamilieInput med numerisk verdi og en definert ref som skal videresendes via designsystemets komponent til selve `<input>`-feltet i bunn. Håper det gjør det enklere for nestemann å vite hvordan man går frem 🙂 