### PR TITLE
fix(Dersom initiell verdi til jaNeiSpm er null, sett den til å være e…

### DIFF
--- a/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
+++ b/packages/familie-form-elements/src/ja-nei-spørsmål/JaNeiSpørsmål.tsx
@@ -41,7 +41,7 @@ export const JaNeiSpørsmål = React.forwardRef(
             description,
         } = props;
 
-        const [checked, setChecked] = useState<ESvar | null>(initiellVerdi);
+        const [checked, setChecked] = useState<ESvar | ''>(initiellVerdi ?? '');
 
         let radios = [
             { label: <Capitalized>{labelTekstForRadios.ja}</Capitalized>, value: ESvar.JA },


### PR DESCRIPTION
…n tom string og ikke undefined)

Fikser denne feilen:
<img width="736" alt="Screenshot 2022-10-12 at 09 48 40" src="https://user-images.githubusercontent.com/8656966/195286265-fe18231e-4bfc-488d-a712-5d111faff508.png">


affects: @navikt/familie-form-elements