### PR TITLE
fix(FamilieInput,FamilieTextarea): sikre at label vises i lesevisning…

### DIFF
--- a/packages/familie-form-elements/src/input/FamilieInput.tsx
+++ b/packages/familie-form-elements/src/input/FamilieInput.tsx
@@ -21,7 +21,12 @@ export const FamilieInput: React.ForwardRefExoticComponent<
         ...restProps
     } = props;
     return erLesevisning ? (
-        <FamilieLesefelt size={size} className={className} label={label} verdi={value === '' ? tekstLesevisning : value} />
+        <FamilieLesefelt
+            size={size}
+            className={className}
+            label={label}
+            verdi={value === '' ? tekstLesevisning : value}
+        />
     ) : (
         <TextField
             size={size}

--- a/packages/familie-form-elements/src/input/FamilieInput.tsx
+++ b/packages/familie-form-elements/src/input/FamilieInput.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, TextField, TextFieldProps } from '@navikt/ds-react';
+import { TextField, TextFieldProps } from '@navikt/ds-react';
 import React, { forwardRef } from 'react';
 import { FamilieLesefelt } from '../lesefelt';
 
@@ -21,11 +21,7 @@ export const FamilieInput: React.ForwardRefExoticComponent<
         ...restProps
     } = props;
     return erLesevisning ? (
-        value === '' ? (
-            <BodyShort className={className} children={tekstLesevisning} />
-        ) : (
-            <FamilieLesefelt size={size} className={className} label={label} verdi={value} />
-        )
+        <FamilieLesefelt size={size} className={className} label={label} verdi={value === '' ? tekstLesevisning : value} />
     ) : (
         <TextField
             size={size}

--- a/packages/familie-form-elements/src/textarea/FamilieTextarea.tsx
+++ b/packages/familie-form-elements/src/textarea/FamilieTextarea.tsx
@@ -18,7 +18,12 @@ export const FamilieTextarea: React.FC<IFamilieTextareaProps> = ({
     ...props
 }) => {
     return erLesevisning ? (
-        <FamilieLesefelt className={className} label={label} verdi={value === '' ? tekstLesevisning : value} size={size} />
+        <FamilieLesefelt
+            className={className}
+            label={label}
+            verdi={value === '' ? tekstLesevisning : value}
+            size={size}
+        />
     ) : (
         <Textarea className={className} label={label} value={value} size={size} {...props}>
             {children}

--- a/packages/familie-form-elements/src/textarea/FamilieTextarea.tsx
+++ b/packages/familie-form-elements/src/textarea/FamilieTextarea.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BodyShort, Textarea, TextareaProps } from '@navikt/ds-react';
+import { Textarea, TextareaProps } from '@navikt/ds-react';
 import { FamilieLesefelt } from '../lesefelt';
 
 export interface IFamilieTextareaProps extends TextareaProps {
@@ -18,11 +18,7 @@ export const FamilieTextarea: React.FC<IFamilieTextareaProps> = ({
     ...props
 }) => {
     return erLesevisning ? (
-        value === '' ? (
-            <BodyShort className={className} children={tekstLesevisning} />
-        ) : (
-            <FamilieLesefelt className={className} label={label} verdi={value} size={size} />
-        )
+        <FamilieLesefelt className={className} label={label} verdi={value === '' ? tekstLesevisning : value} size={size} />
     ) : (
         <Textarea className={className} label={label} value={value} size={size} {...props}>
             {children}


### PR DESCRIPTION
… selv når verdi mangler

affects: @navikt/familie-form-elements

Bruker `FamilieLesefelt` også når vi skal vise fallbacktekst (`tekstLesevisning`), slik at label også vises. Det er viktig for å beskrive konteksten til lesevisningsverdien

Skjermbilder av storybook for FamilieTextarea. FamilieInput er helt tilsvarende
Før:
<img width="249" alt="image" src="https://user-images.githubusercontent.com/2379098/196895610-238e23a4-2512-414d-b178-160ad6918f84.png">

Etter:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/2379098/196895638-1d292e56-86c3-4430-b1a3-210779d6cb35.png">
