### PR TITLE
exporterer kun Counter fra prom-client pga conflicting export av Registry

### DIFF
--- a/packages/familie-backend/src/index.ts
+++ b/packages/familie-backend/src/index.ts
@@ -16,7 +16,7 @@ export * from './config';
 export * from './typer';
 export * from './utils';
 export * from 'openid-client';
-export * from 'prom-client';
+export { Counter } from 'prom-client';
 
 export interface IApp {
     app: Express;


### PR DESCRIPTION
Begge disse inneholder Registry.

```
export * from 'openid-client';
export * from 'prom-client';
```

Hva jeg kan se bruker kun Counter fra prom-client, som brukes som argument i `prometheusTellere?: { [key: string]: Counter<string> },`
Virker som at det kun er BA som bruker denne Counter

Publish feiler, vet ikke helt men den har gjort det tidligere også for brancher som jeg har haft canary deploy på 👀 