### PR TITLE
Omitter value fra DatepickerProps då vi bruker valgtDato fra IDatovel…

### DIFF
--- a/packages/familie-form-elements/src/datovelger/FamilieDatovelger.tsx
+++ b/packages/familie-form-elements/src/datovelger/FamilieDatovelger.tsx
@@ -55,6 +55,7 @@ export const FamilieDatovelger: React.FC<IDatovelgerProps & DatepickerProps> = (
     onChange,
     placeholder,
     valgtDato,
+    value,
     lesevisningFormat = 'DD.MM.YYYY',
     description,
     feil,
@@ -87,7 +88,7 @@ export const FamilieDatovelger: React.FC<IDatovelgerProps & DatepickerProps> = (
                         name: id,
                         placeholder,
                     }}
-                    value={valgtDato}
+                    value={valgtDato || value}
                     onChange={onChange}
                 />
                 {feil && <StyledFeilmelding size={'small'}>{feil}</StyledFeilmelding>}


### PR DESCRIPTION
…gerProps

Føler vi må gjøre noe her. Blir forvirring med både `value` og `valgtDato`

Både jeg og andre bruker value, mens det egentlige er `valgtDato` som skal brukes.
Alternativet er kanskje å bruke `value={valgtDato || value}`? 👀 

`FamilieSelect` bruker `value`