### PR TITLE
fix(datovelger value prop): endret tilbake til å ikke bruke value for…

### DIFF
--- a/packages/familie-form-elements/src/datovelger/FamilieDatovelger.tsx
+++ b/packages/familie-form-elements/src/datovelger/FamilieDatovelger.tsx
@@ -55,7 +55,6 @@ export const FamilieDatovelger: React.FC<IDatovelgerProps & DatepickerProps> = (
     onChange,
     placeholder,
     valgtDato,
-    value,
     lesevisningFormat = 'DD.MM.YYYY',
     description,
     feil,
@@ -88,7 +87,7 @@ export const FamilieDatovelger: React.FC<IDatovelgerProps & DatepickerProps> = (
                         name: id,
                         placeholder,
                     }}
-                    value={valgtDato || value}
+                    value={valgtDato}
                     onChange={onChange}
                 />
                 {feil && <StyledFeilmelding size={'small'}>{feil}</StyledFeilmelding>}


### PR DESCRIPTION
… å unngå uventede sideeffekter

affects: @navikt/familie-form-elements

Pga bruk av `{...}` som sender med value ødela https://github.com/navikt/familie-felles-frontend/pull/709 ba-sak-frontend
Eks
```typescript
<DatoVelger 
{...{value: ...}}
valgtDato={..}
```
https://nav-it.slack.com/archives/CJN0STWB0/p1671634445976279