### PR TITLE
fix(csp for å laste fronts fra nav): designsystem v2 henter fonts fra…

### DIFF
--- a/packages/familie-backend/src/headers.ts
+++ b/packages/familie-backend/src/headers.ts
@@ -2,10 +2,11 @@ import { Express } from 'express';
 
 const styleSource = 'https://fonts.googleapis.com';
 const fontSource = 'https://fonts.gstatic.com';
+const navFontSource = 'https://cdn.nav.no';
 const amplitude = 'https://amplitude.nav.no';
 const sentry = 'https://sentry.gc.nav.no';
 
-const cspString = `default-src 'self' data: ${amplitude} ${sentry}; style-src 'self' ${styleSource} data: 'unsafe-inline'; font-src 'self' ${fontSource} data:; frame-src 'self' blob:;`;
+const cspString = `default-src 'self' data: ${amplitude} ${sentry}; style-src 'self' ${styleSource} data: 'unsafe-inline'; font-src 'self' ${fontSource} ${navFontSource} data:; frame-src 'self' blob:;`;
 
 const setup = (app: Express) => {
     app.disable('x-powered-by');


### PR DESCRIPTION
… ny url

affects: @navikt/familie-backend

Henter fonter fra `https://cdn.nav.no` for v2
https://aksel.nav.no/grunnleggende/guider/migrering#h159a8f039bce