### PR TITLE
chore: flytter @navikt/ds-... pakker til peerDependencies for å unngå…

### DIFF
--- a/packages/familie-clipboard/package.json
+++ b/packages/familie-clipboard/package.json
@@ -29,6 +29,9 @@
         "react-tooltip": "^4.2.21"
     },
     "devDependencies": {
+        "@navikt/ds-css": "2.0.x",
+        "@navikt/ds-icons": "2.0.x",
+        "@navikt/ds-tokens": "2.0.x",
         "@types/styled-components": "^5.1.25",
         "styled-components": "^5.3.5"
     },

--- a/packages/familie-clipboard/package.json
+++ b/packages/familie-clipboard/package.json
@@ -24,9 +24,6 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
-        "@navikt/ds-css": "2.0.x",
-        "@navikt/ds-icons": "2.0.x",
-        "@navikt/ds-tokens": "2.0.x",
         "@types/react-tooltip": "^4.2.4",
         "framer-motion": "^6.3.16",
         "react-tooltip": "^4.2.21"
@@ -37,6 +34,9 @@
     },
     "peerDependencies": {
         "react": "^17.x || 18.x",
-        "styled-components": "^5.x"
+        "styled-components": "^5.x",
+        "@navikt/ds-css": "2.0.x",
+        "@navikt/ds-icons": "2.0.x",
+        "@navikt/ds-tokens": "2.0.x"
     }
 }

--- a/packages/familie-dokumentliste/package.json
+++ b/packages/familie-dokumentliste/package.json
@@ -24,9 +24,6 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
-        "@navikt/ds-css": "^2.0.x",
-        "@navikt/ds-icons": "^2.0.x",
-        "@navikt/ds-react": "^2.0.x",
         "@navikt/familie-ikoner": "^7.0.0",
         "@navikt/familie-typer": "^8.0.0"
     },
@@ -36,6 +33,9 @@
     },
     "peerDependencies": {
         "react": "^17.x || 18.x",
-        "styled-components": "^5.x"
+        "styled-components": "^5.x",
+        "@navikt/ds-css": "^2.0.x",
+        "@navikt/ds-icons": "^2.0.x",
+        "@navikt/ds-react": "^2.0.x"
     }
 }

--- a/packages/familie-dokumentliste/package.json
+++ b/packages/familie-dokumentliste/package.json
@@ -28,6 +28,9 @@
         "@navikt/familie-typer": "^8.0.0"
     },
     "devDependencies": {
+        "@navikt/ds-css": "^2.0.x",
+        "@navikt/ds-icons": "^2.0.x",
+        "@navikt/ds-react": "^2.0.x",
         "@types/styled-components": "^5.1.25",
         "styled-components": "^5.3.5"
     },

--- a/packages/familie-endringslogg/package.json
+++ b/packages/familie-endringslogg/package.json
@@ -24,6 +24,8 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
+        "@navikt/ds-icons": "^2.0.x",
+        "@navikt/ds-react": "^2.0.x",
         "@portabletext/react": "^1.0.6",
         "@types/react-modal": "^3.13.1",
         "classnames": "^2.3.1",

--- a/packages/familie-endringslogg/package.json
+++ b/packages/familie-endringslogg/package.json
@@ -24,8 +24,6 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
-        "@navikt/ds-icons": "^2.0.x",
-        "@navikt/ds-react": "^2.0.x",
         "@portabletext/react": "^1.0.6",
         "@types/react-modal": "^3.13.1",
         "classnames": "^2.3.1",
@@ -34,6 +32,8 @@
     },
     "peerDependencies": {
         "@types/react": "17.x || 18.x",
-        "react": "17.x || 18.x"
+        "react": "17.x || 18.x",
+        "@navikt/ds-icons": "^2.0.x",
+        "@navikt/ds-react": "^2.0.x"
     }
 }

--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -19,9 +19,6 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
-        "@navikt/ds-css": "2.0.x",
-        "@navikt/ds-react": "2.0.x",
-        "@navikt/ds-tokens": "2.0.x",
         "@types/classnames": "^2.3.1",
         "@types/react-select": "^5.0.1",
         "classnames": "^2.3.1",
@@ -43,6 +40,9 @@
     },
     "peerDependencies": {
         "react": "^17.x || 18.x",
-        "styled-components": "^5.x"
+        "styled-components": "^5.x",
+        "@navikt/ds-css": "2.0.x",
+        "@navikt/ds-react": "2.0.x",
+        "@navikt/ds-tokens": "2.0.x"
     }
 }

--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -34,6 +34,9 @@
         "react-select": "^5.4.0"
     },
     "devDependencies": {
+        "@navikt/ds-css": "2.0.x",
+        "@navikt/ds-react": "2.0.x",
+        "@navikt/ds-tokens": "2.0.x",
         "@types/styled-components": "^5.1.25",
         "react-day-picker": "7.4.10",
         "styled-components": "^5.3.5"

--- a/packages/familie-header/package.json
+++ b/packages/familie-header/package.json
@@ -35,6 +35,11 @@
         "styled-components": "^5.3.5"
     },
     "devDependencies": {
+        "@navikt/ds-css": "^2.0.x",
+        "@navikt/ds-css-internal": "^2.0.x",
+        "@navikt/ds-icons": "^2.0.x",
+        "@navikt/ds-react": "^2.0.x",
+        "@navikt/ds-react-internal": "^2.0.x",
         "css-loader": "^6.7.1",
         "less-loader": "^11.0.0",
         "mini-css-extract-plugin": "^2.6.1",

--- a/packages/familie-header/package.json
+++ b/packages/familie-header/package.json
@@ -25,11 +25,6 @@
     },
     "dependencies": {
         "@babel/preset-typescript": "^7.18.6",
-        "@navikt/ds-css": "^2.0.x",
-        "@navikt/ds-css-internal": "^2.0.x",
-        "@navikt/ds-icons": "^2.0.x",
-        "@navikt/ds-react": "^2.0.x",
-        "@navikt/ds-react-internal": "^2.0.x",
         "@navikt/familie-ikoner": "^7.0.0",
         "@navikt/familie-typer": "^8.0.0",
         "@navikt/familie-validering": "^5.0.0",
@@ -52,6 +47,11 @@
     "peerDependencies": {
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x",
-        "styled-components": "^5.x"
+        "styled-components": "^5.x",
+        "@navikt/ds-css": "^2.0.x",
+        "@navikt/ds-css-internal": "^2.0.x",
+        "@navikt/ds-icons": "^2.0.x",
+        "@navikt/ds-react": "^2.0.x",
+        "@navikt/ds-react-internal": "^2.0.x"
     }
 }

--- a/packages/familie-sprakvelger/package.json
+++ b/packages/familie-sprakvelger/package.json
@@ -24,9 +24,6 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
-        "@navikt/ds-css": "^2.0.x",
-        "@navikt/ds-icons": "^2.0.x",
-        "@navikt/ds-react": "^2.0.x",
         "@navikt/familie-form-elements": "^9.0.0",
         "@navikt/familie-ikoner": "^7.0.0",
         "@types/react-aria-menubutton": "^6.2.9",
@@ -40,6 +37,9 @@
     "peerDependencies": {
         "react": "17.x || 18.x",
         "react-intl": "^5.20.12",
-        "styled-components": "^5.x"
+        "styled-components": "^5.x",
+        "@navikt/ds-css": "^2.0.x",
+        "@navikt/ds-icons": "^2.0.x",
+        "@navikt/ds-react": "^2.0.x"
     }
 }

--- a/packages/familie-sprakvelger/package.json
+++ b/packages/familie-sprakvelger/package.json
@@ -30,6 +30,9 @@
         "react-aria-menubutton": "^7.0.3"
     },
     "devDependencies": {
+        "@navikt/ds-css": "^2.0.x",
+        "@navikt/ds-icons": "^2.0.x",
+        "@navikt/ds-react": "^2.0.x",
         "@types/styled-components": "^5.1.25",
         "react-intl": "^5.20.12",
         "styled-components": "^5.3.5"

--- a/packages/familie-visittkort/package.json
+++ b/packages/familie-visittkort/package.json
@@ -24,9 +24,6 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
-        "@navikt/ds-css": "2.0.x",
-        "@navikt/ds-react": "2.0.x",
-        "@navikt/ds-tokens": "2.0.x",
         "@navikt/familie-clipboard": "^9.0.0",
         "@navikt/familie-ikoner": "^7.0.0",
         "@navikt/familie-typer": "^8.0.0",
@@ -38,6 +35,9 @@
     },
     "peerDependencies": {
         "react": "^17.x || 18.x",
-        "styled-components": "^5.x"
+        "styled-components": "^5.x",
+        "@navikt/ds-css": "2.0.x",
+        "@navikt/ds-react": "2.0.x",
+        "@navikt/ds-tokens": "2.0.x"
     }
 }

--- a/packages/familie-visittkort/package.json
+++ b/packages/familie-visittkort/package.json
@@ -31,6 +31,9 @@
         "prop-types": "^15.8.1"
     },
     "devDependencies": {
+        "@navikt/ds-css": "2.0.x",
+        "@navikt/ds-react": "2.0.x",
+        "@navikt/ds-tokens": "2.0.x",
         "styled-components": "^5.3.5"
     },
     "peerDependencies": {


### PR DESCRIPTION
… ulike versjoner

ref https://nav-it.slack.com/archives/CJN0STWB0/p1674119003250939

affects: @navikt/familie-clipboard, @navikt/familie-dokumentliste, @navikt/familie-endringslogg, @navikt/familie-form-elements, @navikt/familie-header, @navikt/familie-sprakvelger, @navikt/familie-visittkort

BREAKING CHANGE:
@navikt/ds-... pakker må manuelt legges inn som en dependency i ef-sak-frontend/ba-sak-frontend osv. dersom de ikke allerede er det