### PR TITLE
fix(header-søk): bruk dark mode-variant av søk i headeren

### DIFF
--- a/packages/familie-header/src/søk/Søk.tsx
+++ b/packages/familie-header/src/søk/Søk.tsx
@@ -66,7 +66,7 @@ export const Søk = ({
 
     return (
         <>
-            <SøkContainer alt-text={'søk'}>
+            <SøkContainer alt-text={'søk'} data-theme="dark">
                 <FnrInputWrapper
                     id={inputId}
                     laster={søkeresultater.status === RessursStatus.HENTER}


### PR DESCRIPTION
affects: @navikt/familie-header

Fra v2.2.0 av designsystemet har secondary button transparent bakgrunn https://github.com/navikt/aksel/pull/1789
Så søket vårt, som bruker light mode av [Search](https://aksel.nav.no/komponenter/core/search) ser ganske gyselig ut. Endrer det til å bruke dark mode. Har tatt avsjekk med Gunn

### 📸 Skjermbilder
#### Før
<img width="1121" alt="Screenshot 2023-02-21 at 09 13 15" src="https://user-images.githubusercontent.com/2379098/220288404-afe1c5ca-d180-4f3d-a153-0bddb3438a7d.png">

#### Etter
<img width="1125" alt="Screenshot 2023-02-21 at 09 12 58" src="https://user-images.githubusercontent.com/2379098/220288432-1573c22e-d4ee-4624-a4c1-fce3113ff4ec.png">
