### PR TITLE
Redis med aiven

### DIFF
--- a/packages/familie-backend/src/auth/session.ts
+++ b/packages/familie-backend/src/auth/session.ts
@@ -57,6 +57,16 @@ export default (
     if (sessionKonfigurasjon.redisFullUrl || sessionKonfigurasjon.redisUrl) {
         const redisClient = lagRedisClient(sessionKonfigurasjon);
 
+        /**
+         * Logge hendelser i redisclient for å debugge merkelige sockettimeouts
+         */
+        redisClient.on('error', err => logError(`Redis Error: ${err}`));
+        redisClient.on('connect', () => logInfo('Redis connected'));
+        redisClient.on('reconnecting', () => logInfo('Redis reconnecting'));
+        redisClient.on('ready', () => {
+            logInfo('Redis ready!');
+        });
+
         redisClient.connect().catch(logError);
         redisClient.unref();
 

--- a/packages/familie-backend/src/auth/session.ts
+++ b/packages/familie-backend/src/auth/session.ts
@@ -10,11 +10,13 @@ import { ISessionKonfigurasjon } from '../typer';
 import RedisStore from 'connect-redis';
 
 const redisClientForAiven = (sessionKonfigurasjon: ISessionKonfigurasjon) => {
+    const pingHvertFjerdeMinutt = 1000 * 60 * 4; // Connection blir ugyldig etter fem minutter, pinger derfor hvert fjerde minutt
     const redisClient = redis.createClient({
         database: 1,
         url: sessionKonfigurasjon.redisFullUrl,
         username: sessionKonfigurasjon.redisBrukernavn,
         password: sessionKonfigurasjon.redisPassord,
+        pingInterval: pingHvertFjerdeMinutt,
     });
     return redisClient;
 };

--- a/packages/familie-backend/src/typer.ts
+++ b/packages/familie-backend/src/typer.ts
@@ -5,6 +5,8 @@ export interface IApi {
 
 export interface ISessionKonfigurasjon {
     redisUrl?: string;
+    redisFullUrl?: string;
+    redisBrukernavn?: string;
     redisPassord?: string;
     navn: string;
     secureCookie: boolean;


### PR DESCRIPTION
Skal legge til rette for å kunne kjøre Aiven Redis istedenfor "hjemmesnekra" redis-oppsett.
Fordelen med dette er at det skal være nedetidsfri oppdatering slik at saksbehandlere ikke blir "kastet ut" av løsningene hver gang nais-teamet kjører oppgradering på tvers og restarter applikasjoner. 

For å bruke redis med aiven må man sende inn parametrene 
```
    redisFullUrl
    redisBrukernavn
    redisPassord
```

Man skal _IKKE_ sende inn `redisUrl` hvis man ønsker å bruke Aiven Redis. 

Alt er bakoverkompatibelt og støtter selvsagt bruk av den gamle redisløsningen da vi ikke klarer å skrive oss bort fra dette med det første. 

[Les mer her om hvordan man setter opp Aiven Redis for en applikasjon](https://docs.nais.io/persistence/redis/?h=redis)