### PR TITLE
Refactor/datovelger i egen pakke

### DIFF
--- a/packages/familie-datovelger/README.md
+++ b/packages/familie-datovelger/README.md
@@ -1,0 +1,17 @@
+# Typer
+
+Datovelger for familie
+
+## Installasjon
+
+```sh
+npm install @navikt/familie-datovelger
+# eller hvis du bruker yarn:
+yarn add @navikt/familie-datovelger
+```
+
+## Anvendelse
+
+Besøk [docs](https://navikt.github.io/familie-felles-frontend) for dokumentasjon.
+
+

--- a/packages/familie-datovelger/datovelger.stories.tsx
+++ b/packages/familie-datovelger/datovelger.stories.tsx
@@ -2,17 +2,16 @@ import React, { useState } from 'react';
 
 import { ISODateString } from 'nav-datovelger/lib/types';
 
-import '../../stories.less';
-import { FamilieDatovelger } from '..';
 import { BodyShort, Switch } from '@navikt/ds-react';
 import '@navikt/ds-css';
+import { FamilieDatovelger } from './src';
 
 export default {
     component: FamilieDatovelger,
     parameters: {
         componentSubtitle: 'En datovelger med støtte for lesevisning.',
     },
-    title: 'Komponenter/Form-elementer/FamilieDatovelger',
+    title: 'Komponenter/FamilieDatovelger',
 };
 
 export const FamilieDatovelgerStory: React.FC = ({ ...args }) => {
@@ -22,7 +21,7 @@ export const FamilieDatovelgerStory: React.FC = ({ ...args }) => {
 
     return (
         <>
-            <div className={'story-elements switch-gruppe'}>
+            <div>
                 <Switch checked={lesevisning} onClick={() => settLesevisning(!lesevisning)}>
                     Lesevisning
                 </Switch>
@@ -30,7 +29,7 @@ export const FamilieDatovelgerStory: React.FC = ({ ...args }) => {
                     Feil
                 </Switch>
             </div>
-            <div className={'story-elements'}>
+            <div>
                 <FamilieDatovelger
                     id={'dato'}
                     label={'Datovelger'}

--- a/packages/familie-datovelger/package.json
+++ b/packages/familie-datovelger/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@navikt/familie-form-elements",
-    "version": "10.1.2",
+    "name": "@navikt/familie-datovelger",
+    "version": "0.0.0",
     "main": "dist/index.js",
     "author": "NAV",
     "license": "MIT",
@@ -21,13 +21,24 @@
     "dependencies": {
         "@types/classnames": "^2.3.1",
         "classnames": "^2.3.2",
-        "react-select": "^5.7.0"
+        "dayjs": "^1.11.3",
+        "nav-datovelger": "^12.6.0",
+        "nav-frontend-core": "^6.0.x",
+        "nav-frontend-js-utils": "^1.0.x",
+        "nav-frontend-knapper-style": "^2.1.1",
+        "nav-frontend-skjema": "^4.0.x",
+        "nav-frontend-skjema-style": "^3.0.2",
+        "nav-frontend-typografi": "^4.0.x",
+        "nav-frontend-typografi-style": "^2.0.1",
+        "react-select": "^5.7.0",
+        "@navikt/familie-form-elements": "^10.1.2"
     },
     "devDependencies": {
         "@navikt/ds-css": "2.x",
         "@navikt/ds-react": "2.x",
         "@navikt/ds-tokens": "2.x",
         "@types/styled-components": "^5.1.25",
+        "react-day-picker": "7.4.10",
         "styled-components": "^5.3.5"
     },
     "peerDependencies": {

--- a/packages/familie-datovelger/src/FamilieDatovelger.tsx
+++ b/packages/familie-datovelger/src/FamilieDatovelger.tsx
@@ -5,9 +5,9 @@ import dayjs from 'dayjs';
 import styled from 'styled-components';
 import { ISODateString } from 'nav-datovelger/lib/types';
 import { DatepickerProps } from 'nav-datovelger/lib/Datepicker';
-import { FamilieLesefelt } from '../lesefelt';
 import { ErrorMessage, Label } from '@navikt/ds-react';
 import { ASurfaceDanger } from '@navikt/ds-tokens/dist/tokens';
+import { FamilieLesefelt } from '@navikt/familie-form-elements';
 
 export interface IDatovelgerProps {
     className?: string;
@@ -65,7 +65,11 @@ export const FamilieDatovelger: React.FC<IDatovelgerProps & DatepickerProps> = (
             <FamilieLesefelt
                 className={className}
                 label={label}
-                verdi={verdiDayjs && verdiDayjs.isValid() ? verdiDayjs.format(lesevisningFormat) : value}
+                verdi={
+                    verdiDayjs && verdiDayjs.isValid()
+                        ? verdiDayjs.format(lesevisningFormat)
+                        : value
+                }
             />
         );
     } else {

--- a/packages/familie-datovelger/src/index.ts
+++ b/packages/familie-datovelger/src/index.ts
@@ -1,0 +1,1 @@
+export * from './FamilieDatovelger';

--- a/packages/familie-datovelger/src/index.ts
+++ b/packages/familie-datovelger/src/index.ts
@@ -1,1 +1,3 @@
 export * from './FamilieDatovelger';
+export * from 'nav-datovelger';
+export * from 'nav-datovelger/lib/types';

--- a/packages/familie-datovelger/tsconfig.json
+++ b/packages/familie-datovelger/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "include": ["src", "types"],
+    "compilerOptions": {
+        "outDir": "./dist",
+    },
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/familie-form-elements/src/datovelger/index.ts
+++ b/packages/familie-form-elements/src/datovelger/index.ts
@@ -1,3 +1,0 @@
-export * from './FamilieDatovelger';
-export * from 'nav-datovelger';
-export * from 'nav-datovelger/lib/types';

--- a/packages/familie-form-elements/src/index.ts
+++ b/packages/familie-form-elements/src/index.ts
@@ -1,6 +1,5 @@
 export * from './checkbox';
 export * from './checkboxgroup';
-export * from './datovelger';
 export * from './input';
 export * from './knapp';
 export * from './lesefelt';


### PR DESCRIPTION
Flytt datovelger i en egen pakke. På grunn av datovelgeren må familie-form-elements fortsatt være avhengig av en del gamle nav-pakker. Gang på gang har dette vært til hinder for oppgraderinger og fiksing av teknisk gjeld i apper som ikke bruker FamilieDatovelger men andre komponenter i familie-form-elements. Har derfor dratt denne ut i en egen pakke inntil noen får tid til å skrive om Datovelger til den nyeste fra Aksel.


Har testet at datovelgeren fortsatt fungerer i ba-sak når den er dratt ut.