### PR TITLE
feat(faser ut @navikt/ds-icons og tar i bruk @navikt/aksel-icons for …

### DIFF
--- a/packages/familie-clipboard/package.json
+++ b/packages/familie-clipboard/package.json
@@ -29,15 +29,15 @@
         "react-tooltip": "^4.2.21"
     },
     "devDependencies": {
+        "@navikt/aksel-icons": "5.x",
         "@navikt/ds-css": "2.x",
-        "@navikt/ds-icons": "2.x",
         "@navikt/ds-tokens": "2.x",
         "@types/styled-components": "^5.1.25",
         "styled-components": "^5.3.5"
     },
     "peerDependencies": {
+        "@navikt/aksel-icons": "5.x",
         "@navikt/ds-css": "2.x || 3.x || 4.x",
-        "@navikt/ds-icons": "2.x",
         "@navikt/ds-tokens": "2.x || 3.x || 4.x",
         "react": "^17.x || 18.x",
         "styled-components": "^5.x"

--- a/packages/familie-clipboard/src/ClipboardIcon.tsx
+++ b/packages/familie-clipboard/src/ClipboardIcon.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Copy, SuccessColored } from '@navikt/ds-icons';
+import { CheckmarkCircleIcon, FilesIcon } from '@navikt/aksel-icons';
 
 interface IProps {
     type: 'check' | 'copy';
     size?: number;
 }
 
-const ClipboardIcon = ({ type, size = 20 }: IProps) => {
+const ClipboardIcon = ({ type, size = 24 }: IProps) => {
     return type === 'check' ? (
-        <SuccessColored
+        <CheckmarkCircleIcon
             fr="mask"
             height={size}
             width={size}
@@ -16,7 +16,7 @@ const ClipboardIcon = ({ type, size = 20 }: IProps) => {
             onResizeCapture={undefined}
         />
     ) : (
-        <Copy
+        <FilesIcon
             fr="mask"
             height={size}
             width={size}

--- a/packages/familie-visittkort/package.json
+++ b/packages/familie-visittkort/package.json
@@ -31,12 +31,14 @@
         "prop-types": "^15.8.1"
     },
     "devDependencies": {
+        "@navikt/aksel-icons": "5.x",
         "@navikt/ds-css": "2.x",
         "@navikt/ds-react": "2.x",
         "@navikt/ds-tokens": "2.x",
         "styled-components": "^5.3.5"
     },
     "peerDependencies": {
+        "@navikt/aksel-icons": "5.x",
         "@navikt/ds-css": "2.x || 3.x || 4.x",
         "@navikt/ds-react": "2.x || 3.x || 4.x",
         "@navikt/ds-tokens": "2.x || 3.x || 4.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3361,6 +3361,11 @@
   resolved "https://npm.pkg.github.com/download/@navikt/aksel-icons/4.9.0/041744a25684a8cee8c3375c2f9b929ea1cdcb93#041744a25684a8cee8c3375c2f9b929ea1cdcb93"
   integrity sha512-WOTkelI+W1VR0VvC6DyTznHcgCcYq5BTWIHU3zmPJMi2ImfmOAP768kGW8imxQ600hN9bTwnjBZixAC5pFsM6A==
 
+"@navikt/aksel-icons@5.x", "@navikt/aksel-icons@^5.0.0":
+  version "5.0.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/aksel-icons/5.0.2/e1d90d3a62bb7a77b02d5fc473daa13a3045713f#e1d90d3a62bb7a77b02d5fc473daa13a3045713f"
+  integrity sha512-rxW5XjjVcTCfcPEc8rKaUoIfgC0TDAkvV1+Xhd+xU0+AAHb71aLPWLbVo1cgF0wajNEv0r99ukUIDgSSEljBHQ==
+
 "@navikt/ds-css@2.x":
   version "2.2.0"
   resolved "https://npm.pkg.github.com/download/@navikt/ds-css/2.2.0/d7625c3de971f9100542f4a19e7e4880252b378c#d7625c3de971f9100542f4a19e7e4880252b378c"


### PR DESCRIPTION
…familie-clipboard. Tar i bruk @navikt/aksel-icons for familie-visttkort

affects: @navikt/familie-clipboard, @navikt/familie-visittkort

BREAKING CHANGE:
Krever versjon 5 av @navikt/aksel-icons for familie-clipboard og familie-visittkort

Før:
![Skjermbilde 2023-08-18 kl  15 30 01](https://github.com/navikt/familie-felles-frontend/assets/32769446/860a2e20-c544-4d44-b0de-561e2a7111ef)
![Skjermbilde 2023-08-18 kl  15 29 46](https://github.com/navikt/familie-felles-frontend/assets/32769446/51d9b9a9-310d-4cc9-ab28-41a60c7cc197)

Etter:
![Skjermbilde 2023-08-18 kl  15 30 18](https://github.com/navikt/familie-felles-frontend/assets/32769446/15a66849-5dd4-44bd-bd01-cc41d0eb77b4)
![Skjermbilde 2023-08-18 kl  15 30 15](https://github.com/navikt/familie-felles-frontend/assets/32769446/e26fef96-fbec-4a00-b367-fed3d6f624c8)
