### PR TITLE
Gjør familie-clipboard deprecated

### DIFF
--- a/packages/familie-clipboard/README.md
+++ b/packages/familie-clipboard/README.md
@@ -1,5 +1,7 @@
 # Clipboard
 
+**Denne komponenten er deprecated og kommer ikke til å bli vedlikeholdt. Designsystemet Aksel har sin egen versjon som brukes i stedet.**
+
 Clipboard komponent som kan brukes for å vise og kopiere tekst.
 
 ## Installasjon

--- a/packages/familie-visittkort/package.json
+++ b/packages/familie-visittkort/package.json
@@ -24,22 +24,21 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
-        "@navikt/familie-clipboard": "^11.0.0",
         "@navikt/familie-ikoner": "^7.0.0",
         "@navikt/familie-typer": "^8.0.0",
         "classnames": "^2.3.2",
         "prop-types": "^15.8.1"
     },
     "devDependencies": {
-        "@navikt/ds-css": "2.x",
-        "@navikt/ds-react": "2.x",
-        "@navikt/ds-tokens": "2.x",
+        "@navikt/ds-css": "4.x",
+        "@navikt/ds-react": "4.x",
+        "@navikt/ds-tokens": "4.x",
         "styled-components": "^5.3.5"
     },
     "peerDependencies": {
-        "@navikt/ds-css": "2.x || 3.x || 4.x",
-        "@navikt/ds-react": "2.x || 3.x || 4.x",
-        "@navikt/ds-tokens": "2.x || 3.x || 4.x",
+        "@navikt/ds-css": "4.x",
+        "@navikt/ds-react": "4.x",
+        "@navikt/ds-tokens": "4.x",
         "react": "^17.x || 18.x",
         "styled-components": "^5.x"
     }

--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -33,7 +33,7 @@ const StyledVisittkort = styled.div`
     }
 `;
 
-const IdentOgKopierKnapp = styled.div`
+const FlexBox = styled.div`
     display: flex;
     align-items: center;
     gap: 0.25rem;
@@ -64,10 +64,10 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
 
             <div className={'visittkort__pipe'}>|</div>
 
-            <IdentOgKopierKnapp>
+            <FlexBox>
                 {ident}
                 <CopyButton copyText={ident} size={'small'} />
-            </IdentOgKopierKnapp>
+            </FlexBox>
 
             {children}
         </StyledVisittkort>

--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -1,9 +1,8 @@
-import Clipboard from '@navikt/familie-clipboard';
 import { FamilieIkonVelger } from '@navikt/familie-ikoner';
 import { kjønnType } from '@navikt/familie-typer';
 import * as React from 'react';
 import styled from 'styled-components';
-import { BodyShort, Label } from '@navikt/ds-react';
+import { CopyButton, Label } from '@navikt/ds-react';
 import { AGray700, ASpacing2, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
 export interface IkonProps {
@@ -34,6 +33,12 @@ const StyledVisittkort = styled.div`
     }
 `;
 
+const IdentOgKopierKnapp = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+`;
+
 export const Visittkort: React.FunctionComponent<IProps> = ({
     alder,
     children,
@@ -59,9 +64,10 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
 
             <div className={'visittkort__pipe'}>|</div>
 
-            <Clipboard>
-                <BodyShort size={'small'}>{ident}</BodyShort>
-            </Clipboard>
+            <IdentOgKopierKnapp>
+                {ident}
+                <CopyButton copyText={ident} size={'small'} />
+            </IdentOgKopierKnapp>
 
             {children}
         </StyledVisittkort>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3414,6 +3414,11 @@
   resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/4.9.0/f93d5c52adb03b266077092b6f4c7d0775af076e#f93d5c52adb03b266077092b6f4c7d0775af076e"
   integrity sha512-HLH8IJ0QmitthGsoftTWWh33JNsbDT+3AoTlMqwwYignbopfr47YB8EnduraHNBWMFwVDU8TSpkT7boVlEsvnQ==
 
+"@navikt/ds-tokens@4.x":
+  version "4.12.1"
+  resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/4.12.1/965d6d0f998cdbe8759d54c47788d67e24240af3#965d6d0f998cdbe8759d54c47788d67e24240af3"
+  integrity sha512-i6kt6D0Zy9/ECRdHw54VoK3bk3oAbY2TsbOiUC0NgBwOOSfR+D/zKCiBXMkbpkQNba8mHrC3RVfNp59pWteAUQ==
+
 "@ndelangen/get-tarball@^3.0.7":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@ndelangen/get-tarball/-/get-tarball-3.0.9.tgz#727ff4454e65f34707e742a59e5e6b1f525d8964"


### PR DESCRIPTION
Et skritt på veien for å fjerne familie-clipboard (Aksel har en komponent som erstatter denne, unødvendig å holde denne pakken oppdatert)

- Bytter ut familie-clipboard med CopyButton fra Aksel i familie-visittkort. Det er noen visuelle forskjeller, se bilder under. Men dette står i stil til andre kopier-knapper i løsningene våre/til nav. Se eksempel på bruk her: https://aksel.nav.no/komponenter/core/copybutton. OBS! Det er en breaking change på familie-visittkort som nå krever ds-pakker versjon 4 (altså er ikke v2 og v3 lenger tillatt, fordi vi trenger en komponent som kun er i v4+)
- Skriver i readme til familie-clipboard at denne komponenten er deprecated

Før
![image](https://github.com/navikt/familie-felles-frontend/assets/25459913/9caaaf39-4260-4d99-ba71-edfe76514c3b)
![image](https://github.com/navikt/familie-felles-frontend/assets/25459913/69d18bbd-34ae-4193-bc62-3f4a03cf24d8)

Etter
![image](https://github.com/navikt/familie-felles-frontend/assets/25459913/e281a44d-b3ba-431f-8ab4-9da67ef5a05f)
![image](https://github.com/navikt/familie-felles-frontend/assets/25459913/88eff1d5-110c-44f1-928a-ef85ca55bbb1)
