### PR TITLE
fix(familie-visittkort): sørger for at kopiert ident ikke er formattert

### DIFF
--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -66,7 +66,7 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
 
             <FlexBox>
                 {ident}
-                <CopyButton copyText={ident} size={'small'} />
+                <CopyButton copyText={ident.replace(' ', '')} size={'small'} />
             </FlexBox>
 
             {children}


### PR DESCRIPTION
Fiks bug jeg innførte her: https://github.com/navikt/familie-felles-frontend/pull/1144/files

Kopiert ident har tidligere fått filtrert vekk mellomrom. Legger tilbake dette. 

Kan diskutere om dette er beste måten å løse det på. Burde man heller gjøre motsatt - sende inn ikke-formattert ident og heller formattere den for visning frontend? Dumme med det er at alle må endre koden, så dette var minste motstands vei fordi ingen må gjøre oppdatering i koden annet enn å ta i bruk nyeste versjon av familie-visittkort.