### PR TITLE
feat(familie-sprakvelger): oppgraderer familie-form-elements som nå tillater aksel v5

### DIFF
--- a/packages/familie-sprakvelger/package.json
+++ b/packages/familie-sprakvelger/package.json
@@ -24,7 +24,7 @@
         "tsc": "tsc -p tsconfig.json"
     },
     "dependencies": {
-        "@navikt/familie-form-elements": "^12.0.0",
+        "@navikt/familie-form-elements": "^13.0.0",
         "@types/react-aria-menubutton": "^6.2.9",
         "react-aria-menubutton": "^7.0.3"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,6 +3015,15 @@
   resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/5.5.0/f963d7872d9b6eb74198f19f107b6073bfa8c6a5#f963d7872d9b6eb74198f19f107b6073bfa8c6a5"
   integrity sha512-zV9TfGNjiRgpX1Ec11gK8BtgkiR+HN+qwjVbWt5NA6ux8xIQYdaFqLJWQa585vLl6DEOhwrlzb0FhT+KDvG3Rg==
 
+"@navikt/familie-form-elements@^13.0.0":
+  version "13.0.0"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-form-elements/13.0.0/c3ec85621cb87c35cece49ce4a0d59d17ab0ad7c#c3ec85621cb87c35cece49ce4a0d59d17ab0ad7c"
+  integrity sha512-C7Co3jFGad7TdS7P2QM1l58rb4T82lE31Gx6gOC7MXRaBKTDnd9MJCf8AXazUyjmxUASmWepdSoGo/bgZjtJdA==
+  dependencies:
+    "@types/classnames" "^2.3.1"
+    classnames "^2.3.2"
+    react-select "^5.7.0"
+
 "@ndelangen/get-tarball@^3.0.7":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@ndelangen/get-tarball/-/get-tarball-3.0.9.tgz#727ff4454e65f34707e742a59e5e6b1f525d8964"


### PR DESCRIPTION
Versjonen av familie-form-elements som ble bruk i språkvelgeren var ikke oppdatert til å håndtere versjon 5 av aksel (som er det språkvelgeren var oppdatert til å bruke)