### PR TITLE
Bedre feilhåndtering av kall mot MS for brukerdata

### DIFF
--- a/packages/familie-backend/src/auth/authenticate.ts
+++ b/packages/familie-backend/src/auth/authenticate.ts
@@ -4,7 +4,6 @@ import { appConfig } from '../config';
 import { LOG_LEVEL } from '@navikt/familie-logging';
 import { getTokenSetsFromSession, tokenSetSelfId, hasValidAccessToken } from './tokenUtils';
 import { Client, TokenSet } from 'openid-client';
-import { setBrukerprofilPåSesjon } from './bruker';
 import { logRequest } from '../utils';
 
 export const authenticateAzure = (req: Request, res: Response, next: NextFunction) => {
@@ -86,15 +85,14 @@ export const ensureAuthenticated = (authClient: Client, sendUnauthorized: boolea
                         return;
                     });
             }
-
-            return setBrukerprofilPåSesjon(authClient, req, next);
-        }
-
-        const pathname = req.originalUrl;
-        if (sendUnauthorized) {
-            res.status(401).send('Unauthorized');
+            return next();
         } else {
-            res.redirect(`/login?redirectUrl=${pathname}`);
+            const pathname = req.originalUrl;
+            if (sendUnauthorized) {
+                res.status(401).send('Unauthorized');
+            } else {
+                res.redirect(`/login?redirectUrl=${pathname}`);
+            }
         }
     };
 };

--- a/packages/familie-backend/src/auth/bruker.ts
+++ b/packages/familie-backend/src/auth/bruker.ts
@@ -51,7 +51,13 @@ const hentBrukerData = (accessToken: string, req: Request) => {
 /**
  * Funksjon som henter brukerprofil fra graph.
  */
-export const setBrukerprofilPåSesjon = (authClient: Client, req: Request, next: NextFunction) => {
+export const setBrukerprofilPåSesjonRute = (authClient: Client) => {
+    return async (req: Request, _: Response, next: NextFunction) => {
+        return setBrukerprofilPåSesjon(authClient, req, next);
+    };
+};
+
+const setBrukerprofilPåSesjon = (authClient: Client, req: Request, next: NextFunction) => {
     return new Promise((_, _reject) => {
         const api = {
             clientId: 'https://graph.microsoft.com',

--- a/packages/familie-backend/src/auth/bruker.ts
+++ b/packages/familie-backend/src/auth/bruker.ts
@@ -16,24 +16,18 @@ export const hentBrukerprofil = () => {
     };
 };
 
-const håndterGenerellFeil = (req: Request, err: Error) => {
-    logRequest(req, `Noe gikk galt: ${err.message}.`, LOG_LEVEL.ERROR);
-
-    throw new Error('Noe gikk galt ved pålogging i løsningen. Vennligst prøv på nytt.');
+const håndterGenerellFeil = (next: NextFunction, req: Request, err: Error) => {
+    logRequest(req, `Noe gikk galt: ${err?.message}.`, LOG_LEVEL.ERROR);
+    next();
 };
+
 const håndterBrukerdataFeil = (req: Request, err: Error) => {
     logRequest(
         req,
         `Feilet mot ms graph: ${err.message}. Kan ikke fortsette uten brukerdata.`,
         LOG_LEVEL.ERROR,
     );
-    if (req.session) {
-        throw new Error('Noe gikk galt ved pålogging i løsningen. Vennligst prøv på nytt.');
-    } else {
-        throw new Error(
-            'Kunne ikke hente dine brukeropplysninger. Vennligst logg ut og inn på nytt.',
-        );
-    }
+    throw new Error('Kunne ikke hente dine brukeropplysninger. Vennligst logg ut og inn på nytt');
 };
 
 const fetchFraMs = (accessToken: string) => {
@@ -100,7 +94,7 @@ export const setBrukerprofilPåSesjon = (authClient: Client, req: Request, next:
                 });
             })
             .catch((err: Error) => {
-                return håndterGenerellFeil(req, err);
+                return håndterGenerellFeil(next, req, err);
             });
     });
 };

--- a/packages/familie-backend/src/router.ts
+++ b/packages/familie-backend/src/router.ts
@@ -7,7 +7,7 @@ import {
     ensureAuthenticated,
     logout,
 } from './auth/authenticate';
-import { hentBrukerprofil } from './auth/bruker';
+import { hentBrukerprofil, setBrukerprofilPåSesjonRute } from './auth/bruker';
 
 const router = express.Router();
 
@@ -24,7 +24,12 @@ export default (authClient: Client, prometheusTellere?: { [key: string]: Counter
     router.get('/auth/logout', (req: Request, res: Response) => logout(req, res));
 
     // Bruker
-    router.get('/user/profile', ensureAuthenticated(authClient, true), hentBrukerprofil());
+    router.get(
+        '/user/profile',
+        ensureAuthenticated(authClient, true),
+        setBrukerprofilPåSesjonRute(authClient),
+        hentBrukerprofil(),
+    );
 
     return router;
 };

--- a/packages/familie-backend/src/utils.ts
+++ b/packages/familie-backend/src/utils.ts
@@ -16,7 +16,9 @@ export const envVar = (navn: string, påkrevd = true, defaultValue?: string): st
 
 const prefix = (req: Request) => {
     return `${
-        req.session && req.session.user ? `${req.session.user.displayName} -` : 'ugyldig sesjon -'
+        req.session && req.session.user
+            ? `${req.session.user.displayName} -`
+            : 'ugyldig sesjon eller mangler brukers data -'
     } ${req.method} - ${req.originalUrl}`;
 };
 


### PR DESCRIPTION
For å unngå at saksbehandlere havner i en tilstand med "ukjent enhet", ingen brukerdata og følgelig ingen grupper (som gjerne defaulter til veiledervisning i saksbehandlingsløsningen) har vi gjort noen endringer. 

1. Tatt bort at man setter tom bruker på sesjonen med "9999" i enhet, men heller kjører igjennom uten bruker dersom det feiler mot MS.
2. Lagt inn slik at man har en retry mot MS før løsningen feiler
3. Trekker ut kall mot MS til profil-endepunktet - og ikke ALLE kall mot backend. Det er kun her vi har behov for denne informasjonen.

Gotcha: Ikke kast feil uten å håndtere de i node express - da krasjer appen og dør ☠️ 