### PR TITLE
Grupper dependabot PRer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,30 @@ updates:
         ignore:
             -   dependency-name: "*"
                 update-types: [ "version-update:semver-patch" ]
-
+        groups:
+            sentry:
+                patterns:
+                    - "@sentry/tracing"
+                    - "@sentry/core"
+                    - "@sentry/browser"
+            typescript-eslint:
+                patterns:
+                    - "@typescript-eslint/eslint-plugin"
+                    - "@typescript-eslint/parser"
+            react:
+                patterns:
+                    - "react"
+                    - "@types/react"
+                    - "react-dom"
+            babel:
+                patterns:
+                    - "@babel/*"
+            aksel:
+                patterns:
+                    - "@navikt/aksel-icons"
+                    - "@navikt/ds-*"
+                exclude-patterns:
+                    - "@navikt/ds-icons"
     -   package-ecosystem: github-actions
         directory: "/"
         schedule:


### PR DESCRIPTION
Grupperer dependabot PRer for avhengighetet som burde oppgraderes samtidig. Prøvd ut i ba-sak-frontend og ks-sak-frontend med stor suksess 😄