### PR TITLE
Feat/oppgrader FamilieVisittkort

### DIFF
--- a/packages/familie-ikoner/ikoner.stories.tsx
+++ b/packages/familie-ikoner/ikoner.stories.tsx
@@ -10,11 +10,11 @@ export default {
     title: 'Komponenter/Ikoner',
 };
 
-export const familievelger: React.FC = ({...args}) => {
+export const familievelger: React.FC = ({ ...args }) => {
     return (
         <>
-            <FamilieIkonVelger alder={30} kjønn={kjønnType.KVINNE} {...args}/>
-            <FamilieIkonVelger alder={30} kjønn={kjønnType.KVINNE}/>
+            <FamilieIkonVelger alder={30} kjønn={kjønnType.UKJENT} {...args} />
+            <FamilieIkonVelger alder={30} kjønn={kjønnType.KVINNE} />
             <FamilieIkonVelger alder={3} kjønn={kjønnType.KVINNE} />
             <FamilieIkonVelger alder={30} kjønn={kjønnType.MANN} />
             <FamilieIkonVelger alder={3} kjønn={kjønnType.MANN} />
@@ -24,13 +24,13 @@ export const familievelger: React.FC = ({...args}) => {
 
 // @ts-ignore
 familievelger.args = {
-    alder: 30
-}
+    alder: 30,
+};
 // @ts-ignore
 familievelger.argTypes = {
     alder: {
         control: {
-            type:'number'
-        }
-    }
-}
+            type: 'number',
+        },
+    },
+};

--- a/packages/familie-visittkort/package.json
+++ b/packages/familie-visittkort/package.json
@@ -32,6 +32,7 @@
         "@navikt/ds-css": "5.x",
         "@navikt/ds-react": "5.x",
         "@navikt/ds-tokens": "5.x",
+        "@navikt/aksel-icons": "5.x",
         "styled-components": "^6.x"
     },
     "peerDependencies": {

--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { CopyButton, HStack, Label } from '@navikt/ds-react';
-import { ABorderStrong, ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
+import { ABorderStrong, ABorderSubtle, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieIkonVelger } from '@navikt/familie-ikoner';
 import { kjønnType } from '@navikt/familie-typer';
 
@@ -17,11 +17,13 @@ export interface IProps extends React.PropsWithChildren {
     navn: string | React.ReactNode;
     ikon?: React.ReactElement;
     dempetKantlinje?: boolean;
+    padding?: boolean;
 }
 
-const StyledVisittkort = styled(HStack)<{ $dempetKantlinje: boolean }>`
+const StyledVisittkort = styled(HStack)<{ $dempetKantlinje: boolean; $padding: boolean }>`
     border-bottom: 1px solid ${props => (props.$dempetKantlinje ? ABorderSubtle : ABorderStrong)};
     height: 3rem;
+    padding: ${props => props.$padding && `0 ${ASpacing4}`};
 `;
 
 const GrådigChildrenContainer = styled.div`
@@ -36,6 +38,7 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
     navn,
     ikon,
     dempetKantlinje = false,
+    padding = false,
 }) => {
     return (
         <StyledVisittkort
@@ -43,6 +46,7 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
             justify="space-between"
             gap="4"
             $dempetKantlinje={dempetKantlinje}
+            $padding={padding}
         >
             <HStack align="center" gap="4">
                 {ikon ? (

--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { CopyButton, HStack, Label } from '@navikt/ds-react';
-import { ABorderStrong } from '@navikt/ds-tokens/dist/tokens';
+import { ABorderStrong, ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieIkonVelger } from '@navikt/familie-ikoner';
 import { kjønnType } from '@navikt/familie-typer';
 
@@ -16,10 +16,11 @@ export interface IProps extends React.PropsWithChildren {
     kjønn: kjønnType;
     navn: string | React.ReactNode;
     ValgfrittIkon?: React.ComponentType<IkonProps>;
+    dempetKantlinje?: boolean;
 }
 
-const StyledVisittkort = styled(HStack)`
-    border-bottom: 1px solid ${ABorderStrong};
+const StyledVisittkort = styled(HStack)<{ $dempetKantlinje: boolean }>`
+    border-bottom: 1px solid ${props => (props.$dempetKantlinje ? ABorderSubtle : ABorderStrong)};
     height: 3rem;
 `;
 
@@ -34,9 +35,15 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
     kjønn,
     navn,
     ValgfrittIkon,
+    dempetKantlinje = false,
 }) => {
     return (
-        <StyledVisittkort align="center" justify="space-between" gap="4">
+        <StyledVisittkort
+            align="center"
+            justify="space-between"
+            gap="4"
+            $dempetKantlinje={dempetKantlinje}
+        >
             <HStack align="center" gap="4">
                 {ValgfrittIkon ? (
                     <ValgfrittIkon width={24} height={24} />

--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -4,12 +4,6 @@ import { CopyButton, HStack, Label } from '@navikt/ds-react';
 import { ABorderStrong, ABorderSubtle, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieIkonVelger } from '@navikt/familie-ikoner';
 import { kjønnType } from '@navikt/familie-typer';
-
-export interface IkonProps {
-    className?: string;
-    height?: number;
-    width?: number;
-}
 export interface IProps extends React.PropsWithChildren {
     alder: number;
     ident: string;

--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -26,7 +26,7 @@ const StyledVisittkort = styled(HStack)<{ $dempetKantlinje: boolean; $padding: b
     padding: ${props => props.$padding && `0 ${ASpacing4}`};
 `;
 
-const GrådigChildrenContainer = styled.div`
+const GrådigChildrenContainer = styled(HStack)`
     flex: 1;
 `;
 
@@ -67,7 +67,9 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
                     <CopyButton copyText={ident.replace(' ', '')} size={'small'} />
                 </HStack>
             </HStack>
-            <GrådigChildrenContainer>{children}</GrådigChildrenContainer>
+            <GrådigChildrenContainer align="center" gap="4">
+                {children}
+            </GrådigChildrenContainer>
         </StyledVisittkort>
     );
 };

--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -1,42 +1,30 @@
-import { FamilieIkonVelger } from '@navikt/familie-ikoner';
-import { kjønnType } from '@navikt/familie-typer';
 import * as React from 'react';
 import styled from 'styled-components';
-import { CopyButton, Label } from '@navikt/ds-react';
-import { AGray700, ASpacing2, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
+import { CopyButton, HStack, Label } from '@navikt/ds-react';
+import { ABorderStrong } from '@navikt/ds-tokens/dist/tokens';
+import { FamilieIkonVelger } from '@navikt/familie-ikoner';
+import { kjønnType } from '@navikt/familie-typer';
 
 export interface IkonProps {
     className?: string;
-    heigth?: number;
+    height?: number;
     width?: number;
 }
-export interface IProps {
+export interface IProps extends React.PropsWithChildren {
     alder: number;
     ident: string;
     kjønn: kjønnType;
     navn: string | React.ReactNode;
     ValgfrittIkon?: React.ComponentType<IkonProps>;
-    children?: React.ReactNode;
 }
 
-const StyledVisittkort = styled.div`
-    border-bottom: 1px solid ${AGray700};
+const StyledVisittkort = styled(HStack)`
+    border-bottom: 1px solid ${ABorderStrong};
     height: 3rem;
-    width: 100%;
-    display: flex;
-    align-items: center;
-    .visittkort__ikon {
-        padding-right: ${ASpacing2};
-    }
-    .visittkort__pipe {
-        padding: 0 ${ASpacing4};
-    }
 `;
 
-const FlexBox = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
+const GrådigChildrenContainer = styled.div`
+    flex: 1;
 `;
 
 export const Visittkort: React.FunctionComponent<IProps> = ({
@@ -48,28 +36,27 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
     ValgfrittIkon,
 }) => {
     return (
-        <StyledVisittkort className={'visittkort'}>
-            {ValgfrittIkon ? (
-                <ValgfrittIkon className={'visittkort__ikon'} width={32} heigth={32} />
-            ) : (
-                <FamilieIkonVelger className={'visittkort__ikon'} alder={alder} kjønn={kjønn} />
-            )}
-            {typeof navn === 'string' ? (
-                <Label size={'small'}>
-                    {navn} ({alder} år)
-                </Label>
-            ) : (
-                navn
-            )}
-
-            <div className={'visittkort__pipe'}>|</div>
-
-            <FlexBox>
-                {ident}
-                <CopyButton copyText={ident.replace(' ', '')} size={'small'} />
-            </FlexBox>
-
-            {children}
+        <StyledVisittkort align="center" justify="space-between" gap="4">
+            <HStack align="center" gap="4">
+                {ValgfrittIkon ? (
+                    <ValgfrittIkon width={24} height={24} />
+                ) : (
+                    <FamilieIkonVelger alder={alder} kjønn={kjønn} width={24} height={24} />
+                )}
+                {typeof navn === 'string' ? (
+                    <Label size={'small'}>
+                        {navn} ({alder} år)
+                    </Label>
+                ) : (
+                    navn
+                )}
+                <div>|</div>
+                <HStack align="center" gap="1">
+                    {ident}
+                    <CopyButton copyText={ident.replace(' ', '')} size={'small'} />
+                </HStack>
+            </HStack>
+            <GrådigChildrenContainer>{children}</GrådigChildrenContainer>
         </StyledVisittkort>
     );
 };

--- a/packages/familie-visittkort/src/index.tsx
+++ b/packages/familie-visittkort/src/index.tsx
@@ -15,7 +15,7 @@ export interface IProps extends React.PropsWithChildren {
     ident: string;
     kjønn: kjønnType;
     navn: string | React.ReactNode;
-    ValgfrittIkon?: React.ComponentType<IkonProps>;
+    ikon?: React.ReactElement;
     dempetKantlinje?: boolean;
 }
 
@@ -34,7 +34,7 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
     ident,
     kjønn,
     navn,
-    ValgfrittIkon,
+    ikon,
     dempetKantlinje = false,
 }) => {
     return (
@@ -45,8 +45,8 @@ export const Visittkort: React.FunctionComponent<IProps> = ({
             $dempetKantlinje={dempetKantlinje}
         >
             <HStack align="center" gap="4">
-                {ValgfrittIkon ? (
-                    <ValgfrittIkon width={24} height={24} />
+                {ikon ? (
+                    ikon
                 ) : (
                     <FamilieIkonVelger alder={alder} kjønn={kjønn} width={24} height={24} />
                 )}

--- a/packages/familie-visittkort/visittkort.stories.tsx
+++ b/packages/familie-visittkort/visittkort.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Buldings3Icon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Dropdown, HStack, Tag } from '@navikt/ds-react';
+import { BodyShort, Button, Dropdown, HStack, Spacer, Tag } from '@navikt/ds-react';
 import { AGreen600, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { kjønnType } from '@navikt/familie-typer';
 
@@ -58,30 +58,27 @@ export const visittkort = ({ ...args }) => {
                 dempetKantlinje
                 padding
             >
-                <HStack justify="space-between" gap="4" align="center">
-                    <HStack gap="4" align="center">
-                        <div>|</div>
-                        <BodyShort>{`Kommunenr: 0181`}</BodyShort>
-                        <Tag variant="neutral-filled" size="small">
-                            Død 01.01.2024
-                        </Tag>
-                    </HStack>
-                    <HStack gap="4" align="center">
-                        <Tag variant="info" size="small" children={`Migrert 01.01.2024`}></Tag>
-                        <BodyShort>Saksoversikt</BodyShort>
-                        <BodyShort>Dokumenter</BodyShort>
-                        <Dropdown>
-                            <Button
-                                variant="secondary"
-                                size="small"
-                                iconPosition={'right'}
-                                as={Dropdown.Toggle}
-                            >
-                                Behandlingsmeny
-                            </Button>
-                        </Dropdown>
-                    </HStack>
+                <HStack gap="4" align="center">
+                    <div>|</div>
+                    <BodyShort>{`Kommunenr: 0181`}</BodyShort>
+                    <Tag variant="neutral-filled" size="small">
+                        Død 01.01.2024
+                    </Tag>
                 </HStack>
+                <Spacer />
+                <Tag variant="info" size="small" children={`Migrert 01.01.2024`}></Tag>
+                <BodyShort>Saksoversikt</BodyShort>
+                <BodyShort>Dokumenter</BodyShort>
+                <Dropdown>
+                    <Button
+                        variant="secondary"
+                        size="small"
+                        iconPosition={'right'}
+                        as={Dropdown.Toggle}
+                    >
+                        Behandlingsmeny
+                    </Button>
+                </Dropdown>
             </Visittkort>
         </>
     );

--- a/packages/familie-visittkort/visittkort.stories.tsx
+++ b/packages/familie-visittkort/visittkort.stories.tsx
@@ -1,10 +1,24 @@
 import React from 'react';
+import styled from 'styled-components';
 
+import { Buldings3Icon } from '@navikt/aksel-icons';
 import { BodyShort, Button, Dropdown, HStack, Tag } from '@navikt/ds-react';
+import { AGreen600, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { kjønnType } from '@navikt/familie-typer';
 
 import Visittkort from './src';
 import '@navikt/ds-css';
+
+const IkonSirkel = styled.span`
+    border-color: ${AGreen600};
+    border-radius: 50%;
+    background-color: ${AGreen600};
+    display: inline-grid;
+    place-items: center;
+    height: ${ASpacing6};
+    width: ${ASpacing6};
+    color: white;
+`;
 
 export default {
     component: Visittkort,
@@ -24,6 +38,17 @@ export const visittkort = ({ ...args }) => {
                 navn="FREDFULL KETSJUP"
                 ident={'123456 78910'}
                 {...args}
+            />
+            <Visittkort
+                alder={12}
+                kjønn={kjønnType.MANN}
+                navn="ROLIG BAJAS"
+                ident={'123456 78910'}
+                ikon={
+                    <IkonSirkel>
+                        <Buldings3Icon width={20} height={20} />
+                    </IkonSirkel>
+                }
             />
             <Visittkort
                 alder={35}

--- a/packages/familie-visittkort/visittkort.stories.tsx
+++ b/packages/familie-visittkort/visittkort.stories.tsx
@@ -58,13 +58,11 @@ export const visittkort = ({ ...args }) => {
                 dempetKantlinje
                 padding
             >
-                <HStack gap="4" align="center">
-                    <div>|</div>
-                    <BodyShort>{`Kommunenr: 0181`}</BodyShort>
-                    <Tag variant="neutral-filled" size="small">
-                        Død 01.01.2024
-                    </Tag>
-                </HStack>
+                <div>|</div>
+                <BodyShort>{`Kommunenr: 0181`}</BodyShort>
+                <Tag variant="neutral-filled" size="small">
+                    Død 01.01.2024
+                </Tag>
                 <Spacer />
                 <Tag variant="info" size="small" children={`Migrert 01.01.2024`}></Tag>
                 <BodyShort>Saksoversikt</BodyShort>

--- a/packages/familie-visittkort/visittkort.stories.tsx
+++ b/packages/familie-visittkort/visittkort.stories.tsx
@@ -30,6 +30,7 @@ export const visittkort = ({ ...args }) => {
                 kjønn={kjønnType.UKJENT}
                 navn="HEMMELIGHETSFULL BIBLIOTEKAR"
                 ident="123456 78910"
+                dempetKantlinje
             >
                 <HStack justify="space-between" gap="4" align="center">
                     <HStack gap="4" align="center">
@@ -71,6 +72,11 @@ visittkort.argTypes = {
     alder: {
         control: {
             type: 'number',
+        },
+    },
+    dempetKantlinje: {
+        control: {
+            type: 'boolean',
         },
     },
 };

--- a/packages/familie-visittkort/visittkort.stories.tsx
+++ b/packages/familie-visittkort/visittkort.stories.tsx
@@ -56,6 +56,7 @@ export const visittkort = ({ ...args }) => {
                 navn="HEMMELIGHETSFULL BIBLIOTEKAR"
                 ident="123456 78910"
                 dempetKantlinje
+                padding
             >
                 <HStack justify="space-between" gap="4" align="center">
                     <HStack gap="4" align="center">
@@ -100,6 +101,11 @@ visittkort.argTypes = {
         },
     },
     dempetKantlinje: {
+        control: {
+            type: 'boolean',
+        },
+    },
+    padding: {
         control: {
             type: 'boolean',
         },

--- a/packages/familie-visittkort/visittkort.stories.tsx
+++ b/packages/familie-visittkort/visittkort.stories.tsx
@@ -1,31 +1,76 @@
-import { kjønnType } from '@navikt/familie-typer';
 import React from 'react';
+
+import { BodyShort, Button, Dropdown, HStack, Tag } from '@navikt/ds-react';
+import { kjønnType } from '@navikt/familie-typer';
+
 import Visittkort from './src';
 import '@navikt/ds-css';
 
 export default {
     component: Visittkort,
     parameters: {
-        componentSubtitle: 'Visittkort brukes til å vise enkel informasjon om en bruker.',
+        componentSubtitle:
+            'Visittkort brukes til å vise enkel informasjon om en bruker. Eksempel nr 2 under er laget for full skjermbredde. ',
     },
     title: 'Komponenter/Visittkort',
 };
 
 export const visittkort = ({ ...args }) => {
     return (
-        <Visittkort
-            alder={30}
-            kjønn={kjønnType.KVINNE}
-            navn={'Mock McMockface'}
-            ident={'12345678910'}
-            {...args}
-        />
+        <>
+            <Visittkort
+                alder={30}
+                kjønn={kjønnType.KVINNE}
+                navn="FREDFULL KETSJUP"
+                ident={'123456 78910'}
+                {...args}
+            />
+            <Visittkort
+                alder={35}
+                kjønn={kjønnType.UKJENT}
+                navn="HEMMELIGHETSFULL BIBLIOTEKAR"
+                ident="123456 78910"
+            >
+                <HStack justify="space-between" gap="4" align="center">
+                    <HStack gap="4" align="center">
+                        <div>|</div>
+                        <BodyShort>{`Kommunenr: 0181`}</BodyShort>
+                        <Tag variant="neutral-filled" size="small">
+                            Død 01.01.2024
+                        </Tag>
+                    </HStack>
+                    <HStack gap="4" align="center">
+                        <Tag variant="info" size="small" children={`Migrert 01.01.2024`}></Tag>
+                        <BodyShort>Saksoversikt</BodyShort>
+                        <BodyShort>Dokumenter</BodyShort>
+                        <Dropdown>
+                            <Button
+                                variant="secondary"
+                                size="small"
+                                iconPosition={'right'}
+                                as={Dropdown.Toggle}
+                            >
+                                Behandlingsmeny
+                            </Button>
+                        </Dropdown>
+                    </HStack>
+                </HStack>
+            </Visittkort>
+        </>
     );
 };
 
 visittkort.args = {
     alder: 30,
     kjønn: kjønnType.KVINNE,
-    navn: 'Mock McMockface',
-    ident: '12345678910',
+    navn: 'FREDFULL KETSJUP',
+    ident: '123456 78910',
+};
+
+visittkort.argTypes = {
+    alder: {
+        control: {
+            type: 'number',
+        },
+    },
 };


### PR DESCRIPTION
Tar i bruk komponenten [HStack fra Aksel](https://aksel.nav.no/komponenter/primitives/hstack) for å løse layouten i familie-visittkort, og legger til et utvidet eksempel på bruk av FamilieVisittkort

Legger til props for å ha en dempet farge på kantlinjen i bunnen ([se kantlinjefarger i Aksel](https://aksel.nav.no/grunnleggende/styling/design-tokens#adb1767e2f87)) samt padding på sidene av visittkortet

Det blir en `BREAKING CHANGE` i familie-visittkort pga endring av props-interface og layoutprinsipper da vi går over til flexbox med fastsatt`gap` heller enn den tidligere løsningen der konsumenten gjerne måtte sette marginverdier på hvert barneelement

Legger også til et eksempel på ikon for ukjent kjønn i dokumentasjonen til FamilieIkonVelger, men dette påvirker ikke selve pakken.

### Skjermbilder

<details>
<summary>Før</summary>

![image](https://github.com/navikt/familie-felles-frontend/assets/2379098/8f96af7e-0cd7-4124-8e72-44c58bdede5d)

</details>
<details>
<summary>Etter</summary>

![image](https://github.com/navikt/familie-felles-frontend/assets/2379098/b06b060a-b38c-407c-8897-95d5436485df)

</details>