### PR TITLE
fix(familie-http): retter opp måten vi bruker constate på slik at det stemmer med dokumentasjon

### DIFF
--- a/packages/familie-http/src/HttpProvider.tsx
+++ b/packages/familie-http/src/HttpProvider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
-import createUseContext from 'constate';
+import constate from 'constate';
 import { Ressurs, ApiRessurs, ISaksbehandler } from '@navikt/familie-typer';
 import { preferredAxios, håndterApiRespons } from './axios';
 
@@ -21,7 +21,7 @@ interface IProps {
     settAutentisert?: (autentisert: boolean) => void;
 }
 
-export const [HttpProvider, useHttp] = createUseContext(
+export const [HttpProvider, useHttp] = constate(
     ({ innloggetSaksbehandler, settAutentisert, fjernRessursSomLasterTimeout = 300 }: IProps) => {
         const [ressurserSomLaster, settRessurserSomLaster] = React.useState<string[]>([]);
 


### PR DESCRIPTION
Fra v2 til v3 i constate så er det endringer i måten man bruker den på, uten at dette er implementert hos oss. Se: https://github.com/diegohaz/constate/blob/bbad5665d124c64f71cadbd6ad44d95a96b02d4d/CHANGELOG.md?plain=1#L57