### PR TITLE
fix(familie-backend): feilhåndtering når det er vedlikehold på Redis …

### DIFF
--- a/packages/familie-backend/src/auth/session.ts
+++ b/packages/familie-backend/src/auth/session.ts
@@ -75,7 +75,10 @@ export default (
         /**
          * Logge hendelser i redisclient for å debugge merkelige sockettimeouts
          */
-        redisClient.on('error', err => logError(`Redis Error: ${err}`));
+        redisClient.on('error', (err) => {
+            logError(`Redis Error: ${err}`)
+            settErforbindelsenTilRedisTilgjengelig(false);
+        });
         redisClient.on('connect', () => logInfo('Redis connected'));
         redisClient.on('reconnecting', () => logInfo('Redis reconnecting'));
         redisClient.on('ready', () => {


### PR DESCRIPTION
…Aiven

For å kunne feilhåndtere når Redis har vedlikehold må vi sette at forbindelsenTilRedis ikke er tilgjengelig når det oppstår en Error-melding. Basert på loggene får vi connect og reconnect-events, men ikke ready-events og da havner appen i limbo-state. Antagelsen er at vi ikke har socket-issues, og dermed slår ikke den koden til. Ulempen her er at det ikke kan reproduseres før neste _vedlikeholdsdag_ i Aiven/Redis-regimet