### PR TITLE
feat(familie-backend): legg på 'rate limit' på autentiseringskall

### DIFF
--- a/packages/familie-backend/package.json
+++ b/packages/familie-backend/package.json
@@ -34,6 +34,7 @@
         "cookie-parser": "^1.4.6",
         "express": "^4.19.2",
         "express-http-proxy": "^2.0.0",
+        "express-rate-limit": "^7.2.0",
         "express-session": "^1.18.0",
         "https-proxy-agent": "^7.0.4",
         "node-fetch": "^3.3.2",

--- a/packages/familie-backend/src/router.ts
+++ b/packages/familie-backend/src/router.ts
@@ -8,10 +8,17 @@ import {
     logout,
 } from './auth/authenticate';
 import { hentBrukerprofil, setBrukerprofilPåSesjonRute } from './auth/bruker';
+import { rateLimit } from 'express-rate-limit';
 
 const router = express.Router();
 
 export default (authClient: Client, prometheusTellere?: { [key: string]: Counter<string> }) => {
+    const limiter = rateLimit({
+        windowMs: 15 * 60 * 1000, // 15 minutter
+        limit: 100, // Max antall per 'vindu' (her 15 minutter)
+    });
+    router.use(limiter);
+
     // Authentication
     router.get('/login', (req: Request, res: Response, next: NextFunction) => {
         if (prometheusTellere && prometheusTellere.login_route) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8162,6 +8162,11 @@ express-http-proxy@^2.0.0:
     es6-promise "^4.1.1"
     raw-body "^2.3.0"
 
+express-rate-limit@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.2.0.tgz#06ce387dd5388f429cab8263c514fc07bf90a445"
+  integrity sha512-T7nul1t4TNyfZMJ7pKRKkdeVJWa2CqB8NA1P8BwYaoDI5QSBZARv5oMS43J7b7I5P+4asjVXjb7ONuwDKucahg==
+
 express-session@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.18.0.tgz#a6ae39d9091f2efba5f20fc5c65a3ce7c9ce16a3"


### PR DESCRIPTION
Fikser opp codeql-feil som skyldes manglende rate limit på autentiseringskall. Fikser det her, ved å følge foreslått guide fra codeql for å fikse problemet. Åpen for å endre tallverdiene, nå brukte jeg bare det som var på eksemplet både fra codeql og dokumentasjonen til express-rate-limit.

https://github.com/navikt/familie-felles-frontend/security/code-scanning/5