### PR TITLE
style(endringslogg): bruk akselfarger for bakgrunn og tekst

### DIFF
--- a/packages/familie-endringslogg/src/endringslogg.css
+++ b/packages/familie-endringslogg/src/endringslogg.css
@@ -50,7 +50,8 @@
 .endringslogg-content {
   overflow: hidden;
   box-shadow: 0 2px 4px 0 rgba(183, 177, 169, 0.5);
-  background-color: white;
+  background-color: var(--a-bg-default);
+    color: var(--a-text-default);
   border-radius: 6px;
   max-width: 27rem;
 }


### PR DESCRIPTION
Tidligere var bare backgrunnsfargen satt, men ikke tekstfargen. Hvis man da feks brukte endringsloggen i en komponent som setter tekstfargen til hvit (feks internal header i aksel) blir teksten hvit, og usynlig mot bakgrunnen.

Ser ellers likt ut i storybook.