### PR TITLE
refactor(dokumentliste): lagt til ny optional props som gjør at man k…

### DIFF
--- a/packages/familie-dokumentliste/dokumentliste.stories.tsx
+++ b/packages/familie-dokumentliste/dokumentliste.stories.tsx
@@ -50,5 +50,10 @@ interface Props {
     dokumenter: DokumentProps[];
 }
 export const Dokumentlistekomponent = (args: Props) => {
-    return <Dokumentliste onClick={lastNedDokument} {...args} />;
+    return (
+        <>
+            <Dokumentliste onClick={lastNedDokument} {...args} />
+            <Dokumentliste onClick={lastNedDokument} skalBrukePiler={false} {...args} />
+        </>
+    );
 };

--- a/packages/familie-dokumentliste/src/index.tsx
+++ b/packages/familie-dokumentliste/src/index.tsx
@@ -5,7 +5,7 @@ import PilNed from '@navikt/familie-ikoner/dist/utils/PilNed';
 import PilHøyre from '@navikt/familie-ikoner/dist/utils/PilHøyre';
 import { ILogiskVedlegg, Journalposttype } from '@navikt/familie-typer';
 import { LogiskeVedlegg } from './LogiskeVedlegg';
-import { Detail, Label } from '@navikt/ds-react';
+import { BodyShort, Detail, Label } from '@navikt/ds-react';
 import '@navikt/ds-css';
 
 const StyledDokumentListe = styled.ul`
@@ -83,20 +83,30 @@ export interface DokumentProps {
 export interface DokumentElementProps {
     dokument: DokumentProps;
     onClick: (dokument: DokumentProps) => void;
+    skalBrukePiler?: boolean;
 }
 
 export interface DokumentlisteProps {
     dokumenter: DokumentProps[];
     onClick: (dokument: DokumentProps) => void;
     className?: string;
+    skalBrukePiler?: boolean;
 }
 
-export const DokumentElement: React.FC<DokumentElementProps> = ({ dokument, onClick }) => {
+export const DokumentElement: React.FC<DokumentElementProps> = ({
+    dokument,
+    onClick,
+    skalBrukePiler,
+}) => {
     return (
         <li>
             <StyledKnapp onClick={() => onClick(dokument)}>
                 <JournalpostIkon>
-                    <Journalpostikon journalposttype={dokument.journalposttype} />
+                    {skalBrukePiler ? (
+                        <Journalpostikon journalposttype={dokument.journalposttype} />
+                    ) : (
+                        <BodyShort>{dokument.journalposttype}</BodyShort>
+                    )}
                 </JournalpostIkon>
                 <StyledDokumentnavn size={'small'}>{dokument.tittel}</StyledDokumentnavn>
                 <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
@@ -106,11 +116,23 @@ export const DokumentElement: React.FC<DokumentElementProps> = ({ dokument, onCl
     );
 };
 
-export const Dokumentliste: React.FC<DokumentlisteProps> = ({ dokumenter, onClick, className }) => {
+export const Dokumentliste: React.FC<DokumentlisteProps> = ({
+    dokumenter,
+    onClick,
+    className,
+    skalBrukePiler = true,
+}) => {
     return (
         <StyledDokumentListe className={className}>
             {dokumenter.map((dokument: DokumentProps, indeks: number) => {
-                return <DokumentElement dokument={dokument} onClick={onClick} key={indeks} />;
+                return (
+                    <DokumentElement
+                        dokument={dokument}
+                        onClick={onClick}
+                        key={indeks}
+                        skalBrukePiler={skalBrukePiler}
+                    />
+                );
             })}
         </StyledDokumentListe>
     );


### PR DESCRIPTION
…an velge å ikke bruke piler

Ved å sette skalBrukePiler til false blir det skrevet bokstaver i stedet for piler for å vise om det er inn/ut eller notat på et dokument.

Dette er fordi vi ønsker å vise bokstaver i stedet for piler på høyre side i dokumentoversikt i ef-sak

![image](https://github.com/navikt/familie-felles-frontend/assets/141132903/f5b696f7-cdcb-4607-93f4-752c9aa3756a)
