### PR TITLE
fix(familie-http, familie-skjema): fikser syntaks på sentry-bruk så vi ikke får byggfeil

### DIFF
--- a/packages/familie-http/src/axios.ts
+++ b/packages/familie-http/src/axios.ts
@@ -1,4 +1,4 @@
-import Sentry, { captureException, withScope } from '@sentry/core';
+import * as Sentry from '@sentry/core';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 
 import { Ressurs, RessursStatus, ApiRessurs, ISaksbehandler } from '@navikt/familie-typer';
@@ -82,13 +82,13 @@ export const loggFeil = (
 
         const response: AxiosResponse | undefined = error ? error.response : undefined;
         if (response) {
-            withScope(scope => {
+            Sentry.withScope(scope => {
                 scope.setExtra('nav-call-id', response.headers['nav-call-id']);
                 scope.setExtra('status text', response.statusText);
                 scope.setExtra('status', response.status);
                 scope.setExtra('feilmelding', feilmelding);
 
-                captureException(error);
+                Sentry.captureException(error);
             });
         }
     }


### PR DESCRIPTION
Får denne feilen når jeg prøver å bruke siste versjon av familie-skjema i ba-sak-frontend:
![image](https://github.com/navikt/familie-felles-frontend/assets/25459913/7d689b82-299f-4420-bd51-a188c526220d)

Ser ut som det skyldes måten man importerer Sentry på fra @sentry/core, så prøver dette