### PR TITLE
fix(familie-endringslogg): den rød dotten med uleste meldinger hadde …

### DIFF
--- a/packages/familie-endringslogg/src/endringslogg.css
+++ b/packages/familie-endringslogg/src/endringslogg.css
@@ -210,8 +210,8 @@
 }
 .ring-container {
   position: relative;
-  bottom: 460px;
-  left: 22px;
+  bottom: 40px;
+  left: 20px;
 }
 .circle {
   width: 1.2rem;
@@ -237,6 +237,7 @@
   font-size: 14px;
   color: white;
   font-weight: bold;
+  padding-top: 2px;
 }
 
 @keyframes pulsate {


### PR DESCRIPTION

…css som skjulte den

Midtstiller tallverdien og viser tall og rød dott i høyre hjørne

![Screenshot 2024-09-23 at 09 33 39](https://github.com/user-attachments/assets/63e3782b-faef-4f32-ba3f-8cf0b4a74e47)
