### PR TITLE
Kan vise ekstra info i brukers dropdown før lenkene i Header

### DIFF
--- a/packages/familie-header/header.stories.tsx
+++ b/packages/familie-header/header.stories.tsx
@@ -8,7 +8,7 @@ import {
     byggTomRessurs,
     Ressurs,
 } from '@navikt/familie-typer';
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, Detail } from '@navikt/ds-react';
 import { idnr } from '@navikt/fnrvalidator';
 import { Endringslogg } from '@navikt/familie-endringslogg';
 
@@ -35,6 +35,15 @@ const popover: PopoverItem = {
         alert('Du har nå logget ut');
     },
 };
+
+const PopoverDetail = () => (
+    <dl>
+        <BodyShort as="dt" size="small">
+            Mer info til saksbehandler
+        </BodyShort>
+        <Detail as="dd">En ekstra detalj her</Detail>
+    </dl>
+);
 
 const eksterneLenkerForStory = [
     { name: 'Google', href: 'https://www.google.com', isExternal: true },
@@ -124,6 +133,7 @@ export const HeaderOgSøk: React.FC = ({ ...args }) => {
             <Header
                 tittel={'tittel'}
                 brukerinfo={saksbehandler}
+                brukerPopoverDetail={<PopoverDetail />}
                 brukerPopoverItems={[popover]}
                 tittelHref={'#'}
                 eksterneLenker={eksterneLenkerForStory}

--- a/packages/familie-header/src/header/Header.tsx
+++ b/packages/familie-header/src/header/Header.tsx
@@ -20,6 +20,7 @@ export interface HeaderProps {
     brukerinfo: Brukerinfo;
     tittelHref?: string;
     children?: React.ReactNode | React.ReactNode[];
+    brukerPopoverDetail?: React.ReactNode;
     brukerPopoverItems?: PopoverItem[];
     eksterneLenker: PopoverItem[];
     tittelOnClick?: () => void;
@@ -28,6 +29,7 @@ export interface HeaderProps {
 interface BrukerProps {
     navn: string;
     enhet?: string;
+    popoverDetail?: React.ReactNode;
     popoverItems?: PopoverItem[];
 }
 
@@ -35,7 +37,7 @@ interface LenkePopoverProps {
     lenker: PopoverItem[];
 }
 
-export const Bruker = ({ navn, enhet, popoverItems }: BrukerProps) => {
+export const Bruker = ({ navn, enhet, popoverItems, popoverDetail }: BrukerProps) => {
     return (
         <Dropdown>
             <NavHeader.UserButton
@@ -44,13 +46,17 @@ export const Bruker = ({ navn, enhet, popoverItems }: BrukerProps) => {
                 description={enhet ? `Enhet: ${enhet}` : 'Ukjent enhet'}
                 className="ml-auto"
             />
-            {popoverItems && (
+            {(popoverItems || popoverDetail) && (
                 <Dropdown.Menu>
-                    <Dropdown.Menu.List>
-                        {popoverItems.map((lenke, index) => {
-                            return <DropdownLenke key={index} lenke={lenke} />;
-                        })}
-                    </Dropdown.Menu.List>
+                    {popoverDetail}
+                    {popoverDetail && popoverItems && <Dropdown.Menu.Divider />}
+                    {popoverItems && (
+                        <Dropdown.Menu.List>
+                            {popoverItems.map((lenke, index) => {
+                                return <DropdownLenke key={index} lenke={lenke} />;
+                            })}
+                        </Dropdown.Menu.List>
+                    )}
                 </Dropdown.Menu>
             )}
         </Dropdown>
@@ -84,14 +90,16 @@ export const LenkePopover = ({ lenker }: LenkePopoverProps) => {
 
 const DropdownLenke: React.FC<{ lenke: PopoverItem }> = ({ lenke }) => {
     return (
-        <a
-            href={lenke.href}
-            target={lenke.isExternal ? '_blank' : ''}
-            rel={lenke.isExternal ? 'noopener noreferrer' : ''}
-            onClick={e => lenke?.onClick && lenke?.onClick(e)}
-        >
-            <Dropdown.Menu.List.Item>{lenke.name}</Dropdown.Menu.List.Item>
-        </a>
+        <Dropdown.Menu.List.Item>
+            <a
+                href={lenke.href}
+                target={lenke.isExternal ? '_blank' : ''}
+                rel={lenke.isExternal ? 'noopener noreferrer' : ''}
+                onClick={e => lenke?.onClick && lenke?.onClick(e)}
+            >
+                {lenke.name}
+            </a>
+        </Dropdown.Menu.List.Item>
     );
 };
 
@@ -100,6 +108,7 @@ export const Header = ({
     children,
     brukerinfo,
     tittelHref = '/',
+    brukerPopoverDetail,
     brukerPopoverItems,
     eksterneLenker = [],
     tittelOnClick,
@@ -118,6 +127,7 @@ export const Header = ({
             <Bruker
                 navn={brukerinfo.navn}
                 enhet={brukerinfo.enhet}
+                popoverDetail={brukerPopoverDetail}
                 popoverItems={brukerPopoverItems}
             />
         </NavHeader>


### PR DESCRIPTION
Vi ønsker å legge på mer info i brukers dropdown. Per [Aksel](https://aksel.nav.no/komponenter/core/i-header#headerdemo-brukermeny) har vi mulighet til å også legge med tekstinnhold. Slik eksempelet er i Aksel ligger denne infoen på toppen, som jeg synes gir veldig mening i den konteksten.

Jeg har dermed valgt å legge til en ny prop `popoverDetail`. Denne legger seg alltid på toppen hvis den finnes. Alt ser ut som før hvis denne ikke inkluderes, som tilrettelegger for en smooth minor upgrade. 😊 

----

Skjermbilde fra Storybook med `popoverDetail`:
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/7aca6af2-a53a-4158-b0ac-ec63e7478036" />

---

Skjermbilde fra Storybook uten `popoverDetail`, da ser alt ut som før:
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/a6dc5274-7129-4a6f-b453-e7bf695fc42b" />
