### PR TITLE
feat(header): mulighet for visning av label og ikon på header

### DIFF
--- a/packages/familie-header/header.stories.tsx
+++ b/packages/familie-header/header.stories.tsx
@@ -45,6 +45,7 @@ const PopoverDetail = () => (
 );
 
 const eksterneLenkerForStory: PopoverItem[] = [
+    { name: 'NRK', href: 'https://www.nrk.no', isExternal: true },
     {
         name: 'Side med onClick',
         onSelect: () => {
@@ -146,6 +147,7 @@ export const HeaderOgSøk: React.FC = ({ ...args }) => {
                 tittelOnClick={() => {
                     alert('du trykket på tittelen');
                 }}
+                skalViseLabelsOgIkonPåLenker={true}
                 {...args}
             >
                 <Søk

--- a/packages/familie-header/src/header/Header.tsx
+++ b/packages/familie-header/src/header/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import '@navikt/ds-css';
 import { ActionMenu, InternalHeader as NavHeader } from '@navikt/ds-react';
 import { MenuGridIcon } from '@navikt/aksel-icons';
+import { EksternLinkIkon } from '@navikt/familie-ikoner';
 
 export interface Brukerinfo {
     navn: string;
@@ -26,6 +27,7 @@ export interface HeaderProps {
     brukerPopoverItems?: PopoverItem[];
     eksterneLenker: PopoverItem[];
     tittelOnClick?: () => void;
+    skalViseLabelsOgIkonPåLenker?: boolean;
 }
 
 interface BrukerProps {
@@ -69,11 +71,7 @@ export const Bruker = ({ navn, enhet, popoverItems, popoverDetail }: BrukerProps
 export const LenkePopover = ({ lenker }: LenkePopoverProps) => {
     return (
         <ActionMenu>
-            <ActionMenu.Trigger>
-                <NavHeader.Button className="ml-auto">
-                    <MenuGridIcon fontSize={'1.5rem'} title="Andre systemer" />
-                </NavHeader.Button>
-            </ActionMenu.Trigger>
+            <ActionMenuTrigger />
             {lenker && (
                 <ActionMenu.Content>
                     <ActionMenu.Group label={''}>
@@ -87,9 +85,50 @@ export const LenkePopover = ({ lenker }: LenkePopoverProps) => {
     );
 };
 
-const ActionMenuLenke: React.FC<{ lenke: PopoverItem }> = ({ lenke }) => {
-    return lenke.onSelect ? (
-        <ActionMenu.Item onSelect={e => lenke?.onSelect && lenke?.onSelect(e)}>
+const ActionMenuMedLabelOgIkoner: React.FC<{
+    lenker: PopoverItem[];
+}> = ({ lenker }) => {
+    const interneLenker = lenker.filter(lenke => !lenke.isExternal);
+    const eksterneLenker = lenker.filter(lenke => lenke.isExternal);
+    return (
+        <ActionMenu>
+            <ActionMenuTrigger />
+            {lenker && (
+                <ActionMenu.Content>
+                    {interneLenker.length > 0 && (
+                        <ActionMenu.Group label="">
+                            {interneLenker.map((lenke, index) => (
+                                <ActionMenuLenke
+                                    lenke={lenke}
+                                    skalHaIkonPåLenke={true}
+                                    key={index}
+                                />
+                            ))}
+                        </ActionMenu.Group>
+                    )}
+                    {eksterneLenker.length > 0 && (
+                        <ActionMenu.Group label="Lenker">
+                            {eksterneLenker.map((lenke, index) => (
+                                <ActionMenuLenke
+                                    lenke={lenke}
+                                    skalHaIkonPåLenke={true}
+                                    key={index + interneLenker.length}
+                                />
+                            ))}
+                        </ActionMenu.Group>
+                    )}
+                </ActionMenu.Content>
+            )}
+        </ActionMenu>
+    );
+};
+
+const ActionMenuLenke: React.FC<{
+    lenke: PopoverItem;
+    skalHaIkonPåLenke?: boolean;
+}> = ({ lenke, skalHaIkonPåLenke }) =>
+    lenke.onSelect ? (
+        <ActionMenu.Item onSelect={e => lenke.onSelect && lenke.onSelect(e)}>
             {lenke.name}
         </ActionMenu.Item>
     ) : (
@@ -99,10 +138,10 @@ const ActionMenuLenke: React.FC<{ lenke: PopoverItem }> = ({ lenke }) => {
             target={lenke.isExternal ? '_blank' : ''}
             rel={lenke.isExternal ? 'noopener noreferrer' : ''}
         >
+            {skalHaIkonPåLenke && lenke.isExternal && <EksternLinkIkon width={16} height={16} />}
             {lenke.name}
         </ActionMenu.Item>
     );
-};
 
 export const Header = ({
     tittel,
@@ -113,6 +152,7 @@ export const Header = ({
     brukerPopoverItems,
     eksterneLenker = [],
     tittelOnClick,
+    skalViseLabelsOgIkonPåLenker: skalViseOverskrifterOgIkonPåLenker,
 }: HeaderProps) => {
     return (
         <NavHeader data-theme={''}>
@@ -124,7 +164,13 @@ export const Header = ({
             )}
             <div style={{ marginLeft: 'auto' }} />
             {children}
-            {eksterneLenker.length > 0 && <LenkePopover lenker={eksterneLenker} />}
+            {eksterneLenker.length > 0 &&
+                (skalViseOverskrifterOgIkonPåLenker ? (
+                    <ActionMenuMedLabelOgIkoner lenker={eksterneLenker} />
+                ) : (
+                    <LenkePopover lenker={eksterneLenker} />
+                ))}
+
             <Bruker
                 navn={brukerinfo.navn}
                 enhet={brukerinfo.enhet}
@@ -132,5 +178,15 @@ export const Header = ({
                 popoverItems={brukerPopoverItems}
             />
         </NavHeader>
+    );
+};
+
+const ActionMenuTrigger = () => {
+    return (
+        <ActionMenu.Trigger>
+            <NavHeader.Button className="ml-auto">
+                <MenuGridIcon fontSize={'1.5rem'} title="Andre systemer" />
+            </NavHeader.Button>
+        </ActionMenu.Trigger>
     );
 };

--- a/packages/familie-ikoner/src/familie/EksternLinkIkon.tsx
+++ b/packages/familie-ikoner/src/familie/EksternLinkIkon.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface IEksternLinkIkon {
+    className?: string;
+    height?: number;
+    width?: number;
+}
+
+export const EksternLinkIkon: React.FC<IEksternLinkIkon> = ({
+    className,
+    height = 32,
+    width = 32,
+}) => {
+    return (
+        <svg
+            aria-labelledby={'ekstern link'}
+            xmlns="http://www.w3.org/2000/svg"
+            className={className}
+            height={height}
+            width={width}
+            fill="none"
+            viewBox="0 0 24 24"
+            focusable="false"
+            role="img"
+        >
+            <path
+                fill="currentColor"
+                fillRule="evenodd"
+                d="M20.532 3.471A.75.75 0 0 1 20.75 4v7.5a.75.75 0 0 1-1.5 0V5.81l-8.72 8.72a.75.75 0 1 1-1.06-1.06l8.72-8.72H12.5a.75.75 0 0 1 0-1.5H20c.206 0 .393.083.529.218l.001.002zM4.75 9A.25.25 0 0 1 5 8.75h7a.75.75 0 0 0 0-1.5H5A1.75 1.75 0 0 0 3.25 9v10c0 .966.784 1.75 1.75 1.75h10A1.75 1.75 0 0 0 16.75 19v-7a.75.75 0 0 0-1.5 0v7a.25.25 0 0 1-.25.25H5a.25.25 0 0 1-.25-.25z"
+                clipRule="evenodd"
+            ></path>
+        </svg>
+    );
+};

--- a/packages/familie-ikoner/src/familie/index.ts
+++ b/packages/familie-ikoner/src/familie/index.ts
@@ -4,3 +4,4 @@ export * from './JenteIkon';
 export * from './KvinneIkon';
 export * from './MannIkon';
 export * from './NøytralPersonIkon';
+export * from './EksternLinkIkon';


### PR DESCRIPTION
Lagt til optional property på header, denne brukes slik at label "Lenker" vises over eksterne lenker, samt ikoner foran lenker.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24000)
Uten:
![image](https://github.com/user-attachments/assets/fe31defb-0a12-4618-a16b-5b19b3a686b1)

Med:
![image](https://github.com/user-attachments/assets/f3f45801-2893-4ec5-84cb-7e600d87febe)