### PR TITLE
Vi legger til callId i ressurs objektet og legger det til i frontend meldinga hvis den finnes meldinga hvis den finnes

### DIFF
--- a/packages/familie-http/src/axios.ts
+++ b/packages/familie-http/src/axios.ts
@@ -50,7 +50,7 @@ export const håndterApiRespons = <T>(apiRespons: ApiRespons<T>): Ressurs<T> => 
 
             const feilmelding = ressurs.frontendFeilmelding ?? defaultFeilmelding;
             const frontendFeilmelding = ressurs.callId
-                ? `${feilmelding} (${ressurs.callId})`
+                ? `${feilmelding} (CallId: ${ressurs.callId})`
                 : feilmelding;
 
             typetRessurs = {

--- a/packages/familie-http/src/axios.ts
+++ b/packages/familie-http/src/axios.ts
@@ -45,13 +45,20 @@ export const håndterApiRespons = <T>(apiRespons: ApiRespons<T>): Ressurs<T> => 
                 status: RessursStatus.IKKE_TILGANG,
             };
             break;
-        case RessursStatus.FEILET:
+        case RessursStatus.FEILET: {
             loggFeilTilSentry && loggFeil(error, innloggetSaksbehandler, ressurs.melding);
+
+            const feilmelding = ressurs.frontendFeilmelding ?? defaultFeilmelding;
+            const frontendFeilmelding = ressurs.callId
+                ? `${feilmelding} (${ressurs.callId})`
+                : feilmelding;
+
             typetRessurs = {
-                frontendFeilmelding: ressurs.frontendFeilmelding ?? defaultFeilmelding,
+                frontendFeilmelding,
                 status: RessursStatus.FEILET,
             };
             break;
+        }
         case RessursStatus.FUNKSJONELL_FEIL:
             typetRessurs = {
                 frontendFeilmelding:

--- a/packages/familie-http/src/axios.ts
+++ b/packages/familie-http/src/axios.ts
@@ -48,15 +48,16 @@ export const håndterApiRespons = <T>(apiRespons: ApiRespons<T>): Ressurs<T> => 
         case RessursStatus.FEILET: {
             loggFeilTilSentry && loggFeil(error, innloggetSaksbehandler, ressurs.melding);
 
-            const feilmelding = ressurs.frontendFeilmelding ?? defaultFeilmelding;
-            const frontendFeilmelding = ressurs.callId
-                ? `${feilmelding} (CallId: ${ressurs.callId})`
-                : feilmelding;
+            const frontendFeilmelding = ressurs.frontendFeilmelding ?? defaultFeilmelding;
+            const frontendFeilmeldingMedEllerUtenCallId = ressurs.callId
+                ? `${frontendFeilmelding} (${ressurs.callId})`
+                : frontendFeilmelding;
 
             typetRessurs = {
-                frontendFeilmelding,
+                frontendFeilmelding: frontendFeilmeldingMedEllerUtenCallId,
                 status: RessursStatus.FEILET,
             };
+
             break;
         }
         case RessursStatus.FUNKSJONELL_FEIL:

--- a/packages/familie-typer/src/ressurs.ts
+++ b/packages/familie-typer/src/ressurs.ts
@@ -13,6 +13,7 @@ export type ApiRessurs<T> = {
     melding: string;
     frontendFeilmelding?: string;
     stacktrace: string;
+    callId?: string;
 };
 
 export type Ressurs<T> =


### PR DESCRIPTION
Vi legger til callId i ressurs objektet og legger det til i frontend meldinga hvis den finnes.

Ved bruk av ny familie-felles-frontend versjon + oversending av callId fra backend vil det se sånn her ut ved feil:

![CAAALL ID](https://github.com/user-attachments/assets/9e168bda-aaf7-4cc8-ba82-cb369c6e4d23)
