### PR TITLE
Legger til cdn.nav.no i CSP-whitelist, umami sitt sporingsscript ligger der

### DIFF
--- a/packages/familie-backend/src/headers.ts
+++ b/packages/familie-backend/src/headers.ts
@@ -7,8 +7,9 @@ const amplitude = 'https://amplitude.nav.no';
 const sentry = 'https://sentry.gc.nav.no';
 const navTelemetry = 'https://telemetry.nav.no';
 const navTelemetryDev = 'https://telemetry.ekstern.dev.nav.no';
+const navCdn = 'https://cdn.nav.no';
 
-const cspString = `default-src 'self' data: ${amplitude} ${sentry} ${navTelemetry} ${navTelemetryDev}; style-src 'self' ${styleSource} data: 'unsafe-inline'; font-src 'self' ${fontSource} ${navFontSource} data:; frame-src 'self' blob:;`;
+const cspString = `default-src 'self' data: ${amplitude} ${sentry} ${navTelemetry} ${navTelemetryDev} ${navCdn}; style-src 'self' ${styleSource} data: 'unsafe-inline'; font-src 'self' ${fontSource} ${navFontSource} data:; frame-src 'self' blob:;`;
 
 const setup = (app: Express) => {
     app.disable('x-powered-by');


### PR DESCRIPTION
CSP-policyen vår må inkludere cdn.nav.no for at Umami sitt tracking-script skal fungere.

<img width="916" alt="image" src="https://github.com/user-attachments/assets/073abb05-d52f-4416-bf91-bc547a29c581" />
