### PR TITLE
Legger til CSP-header for Umami

### DIFF
--- a/packages/familie-backend/src/headers.ts
+++ b/packages/familie-backend/src/headers.ts
@@ -8,8 +8,9 @@ const sentry = 'https://sentry.gc.nav.no';
 const navTelemetry = 'https://telemetry.nav.no';
 const navTelemetryDev = 'https://telemetry.ekstern.dev.nav.no';
 const navCdn = 'https://cdn.nav.no';
+const navUmami = 'https://umami.nav.no';
 
-const cspString = `default-src 'self' data: ${amplitude} ${sentry} ${navTelemetry} ${navTelemetryDev} ${navCdn}; style-src 'self' ${styleSource} data: 'unsafe-inline'; font-src 'self' ${fontSource} ${navFontSource} data:; frame-src 'self' blob:;`;
+const cspString = `default-src 'self' data: ${amplitude} ${sentry} ${navTelemetry} ${navTelemetryDev} ${navCdn} ${navUmami}; style-src 'self' ${styleSource} data: 'unsafe-inline'; font-src 'self' ${fontSource} ${navFontSource} data:; frame-src 'self' blob:;`;
 
 const setup = (app: Express) => {
     app.disable('x-powered-by');


### PR DESCRIPTION
Det manglet en CSP-header til for å få Umami til å fungere, denne gangen for endepunktet vi sender events til.