### PR TITLE
Fjerner constate, useHttp må nå alltid brukes inni en HttpProvider

### DIFF
--- a/packages/familie-http/package.json
+++ b/packages/familie-http/package.json
@@ -26,8 +26,7 @@
     },
     "dependencies": {
         "@navikt/familie-typer": "^8.0.3",
-        "@sentry/core": "^8.50.0",
-        "constate": "^3.3.2"
+        "@sentry/core": "^8.50.0"
     },
     "peerDependencies": {
         "axios": "1.x",

--- a/packages/familie-http/src/HttpProvider.tsx
+++ b/packages/familie-http/src/HttpProvider.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { createContext, PropsWithChildren, useContext } from 'react';
 import { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
-import constate from 'constate';
 import { Ressurs, ApiRessurs, ISaksbehandler } from '@navikt/familie-typer';
 import { preferredAxios, håndterApiRespons } from './axios';
 
@@ -15,70 +14,91 @@ export type FamilieRequest = <SkjemaData, SkjemaRespons>(
     config: FamilieRequestConfig<SkjemaData>,
 ) => Promise<Ressurs<SkjemaRespons>>;
 
+interface HttpContext {
+    systemetLaster: () => boolean;
+    request: FamilieRequest;
+}
+
+const HttpContext = createContext<HttpContext | undefined>(undefined);
+
 interface IProps {
     fjernRessursSomLasterTimeout?: number;
     innloggetSaksbehandler?: ISaksbehandler;
     settAutentisert?: (autentisert: boolean) => void;
 }
 
-export const [HttpProvider, useHttp] = constate(
-    ({ innloggetSaksbehandler, settAutentisert, fjernRessursSomLasterTimeout = 300 }: IProps) => {
-        const [ressurserSomLaster, settRessurserSomLaster] = React.useState<string[]>([]);
+export function HttpProvider(props: PropsWithChildren<IProps>) {
+    const [ressurserSomLaster, settRessurserSomLaster] = React.useState<string[]>([]);
+    const { innloggetSaksbehandler, settAutentisert } = props;
+    const fjernRessursSomLasterTimeout = 300;
 
-        const fjernRessursSomLaster = (ressursId: string) => {
-            setTimeout(() => {
-                settRessurserSomLaster((prevState: string[]) => {
-                    return prevState.filter((ressurs: string) => ressurs !== ressursId);
+    const fjernRessursSomLaster = (ressursId: string) => {
+        setTimeout(() => {
+            settRessurserSomLaster((prevState: string[]) => {
+                return prevState.filter((ressurs: string) => ressurs !== ressursId);
+            });
+        }, fjernRessursSomLasterTimeout);
+    };
+
+    const systemetLaster = () => {
+        return ressurserSomLaster.length > 0;
+    };
+
+    const request: FamilieRequest = async <SkjemaData, SkjemaRespons>(
+        config: FamilieRequestConfig<SkjemaData>,
+    ): Promise<Ressurs<SkjemaRespons>> => {
+        const ressursId = `${config.method}_${config.url}`;
+        config.påvirkerSystemLaster && settRessurserSomLaster([...ressurserSomLaster, ressursId]);
+
+        return preferredAxios
+            .request(config)
+            .then((response: AxiosResponse<ApiRessurs<SkjemaRespons>>) => {
+                const responsRessurs: ApiRessurs<SkjemaRespons> = response.data;
+
+                config.påvirkerSystemLaster && fjernRessursSomLaster(ressursId);
+                return håndterApiRespons({
+                    defaultFeilmelding: config.defaultFeilmelding,
+                    innloggetSaksbehandler,
+                    loggFeilTilSentry: config.loggFeilTilSentry,
+                    ressurs: responsRessurs,
                 });
-            }, fjernRessursSomLasterTimeout);
-        };
+            })
+            .catch((error: AxiosError<ApiRessurs<SkjemaRespons>>) => {
+                if (error.message.includes('401') && settAutentisert) {
+                    settAutentisert(false);
+                }
 
-        const systemetLaster = () => {
-            return ressurserSomLaster.length > 0;
-        };
+                config.påvirkerSystemLaster && fjernRessursSomLaster(ressursId);
 
-        const request: FamilieRequest = async <SkjemaData, SkjemaRespons>(
-            config: FamilieRequestConfig<SkjemaData>,
-        ): Promise<Ressurs<SkjemaRespons>> => {
-            const ressursId = `${config.method}_${config.url}`;
-            config.påvirkerSystemLaster &&
-                settRessurserSomLaster([...ressurserSomLaster, ressursId]);
-
-            return preferredAxios
-                .request(config)
-                .then((response: AxiosResponse<ApiRessurs<SkjemaRespons>>) => {
-                    const responsRessurs: ApiRessurs<SkjemaRespons> = response.data;
-
-                    config.påvirkerSystemLaster && fjernRessursSomLaster(ressursId);
-                    return håndterApiRespons({
-                        defaultFeilmelding: config.defaultFeilmelding,
-                        innloggetSaksbehandler,
-                        loggFeilTilSentry: config.loggFeilTilSentry,
-                        ressurs: responsRessurs,
-                    });
-                })
-                .catch((error: AxiosError<ApiRessurs<SkjemaRespons>>) => {
-                    if (error.message.includes('401') && settAutentisert) {
-                        settAutentisert(false);
-                    }
-
-                    config.påvirkerSystemLaster && fjernRessursSomLaster(ressursId);
-
-                    const responsRessurs: ApiRessurs<SkjemaRespons> | undefined =
-                        error.response?.data;
-                    return håndterApiRespons({
-                        defaultFeilmelding: config.defaultFeilmelding,
-                        error,
-                        innloggetSaksbehandler,
-                        loggFeilTilSentry: true,
-                        ressurs: responsRessurs,
-                    });
+                const responsRessurs: ApiRessurs<SkjemaRespons> | undefined = error.response?.data;
+                return håndterApiRespons({
+                    defaultFeilmelding: config.defaultFeilmelding,
+                    error,
+                    innloggetSaksbehandler,
+                    loggFeilTilSentry: true,
+                    ressurs: responsRessurs,
                 });
-        };
+            });
+    };
 
-        return {
-            systemetLaster,
-            request,
-        };
-    },
-);
+    return (
+        <HttpContext.Provider
+            value={{
+                systemetLaster,
+                request,
+            }}
+        >
+            {props.children}
+        </HttpContext.Provider>
+    );
+}
+
+export function useHttp() {
+    const context = useContext(HttpContext);
+
+    if (context === undefined) {
+        throw new Error('useHttp må brukes innenfor HttpProvider');
+    }
+
+    return context;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5011,11 +5011,6 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==
 
-constate@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/constate/-/constate-3.3.2.tgz#a6cd2f3c203da2cb863f47d22a330b833936c449"
-  integrity sha512-ZnEWiwU6QUTil41D5EGpA7pbqAPGvnR9kBjko8DzVIxpC60mdNKrP568tT5WLJPAxAOtJqJw60+h79ot/Uz1+Q==
-
 content-disposition@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.0.0.tgz#844426cb398f934caefcbb172200126bc7ceace2"


### PR DESCRIPTION
BREAKING CHANGE: useHttp må nå alltid brukes inni en HttpProvider. Går vekk fra constate og skriver oss om til en React-context med en egen Provider-komponent og en egen hook.

Jeg har sjekket og tror ikke dette er en breaking change for noen siden alle løsningene jeg sjekket allerede wrapper alt i en `HttpProvider`. Da er det ingen endringer som må gjøres for å ta denne versjonen i bruk. Men teoretisk sett kan det bli breaking change for noen hvis løsningen ikke wrappes med `HttpProvider` fra før av. 

Tenkte uansett det er fint å si ifra i tilfelle denne oppdateringen feiler for noen. ☺️ 