### PR TITLE
Fiks filendelser for ES-moduler (ESM)

### DIFF
--- a/packages/familie-backend/package.json
+++ b/packages/familie-backend/package.json
@@ -22,7 +22,8 @@
     "scripts": {
         "build": "yarn run clean && yarn run compile",
         "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
-        "compile": "tsc -b tsconfig.json"
+        "compile": "tsc -b tsconfig.json && yarn run tsc-alias",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "@navikt/familie-logging": "^7.0.3",
@@ -41,5 +42,8 @@
         "passport": "^0.7.0",
         "prom-client": "^15.1.3",
         "redis": "^4.7.0"
+    },
+    "devDependencies": {
+        "tsc-alias": "^1.8.16"
     }
 }

--- a/packages/familie-endringslogg/package.json
+++ b/packages/familie-endringslogg/package.json
@@ -19,10 +19,11 @@
         "dist"
     ],
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 \"src/**/*.css\"  dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "@portabletext/react": "^3.2.0",
@@ -30,7 +31,8 @@
     },
     "devDependencies": {
         "@navikt/aksel-icons": "7.x",
-        "@navikt/ds-react": "7.x"
+        "@navikt/ds-react": "7.x",
+        "tsc-alias": "^1.8.16"
     },
     "peerDependencies": {
         "@navikt/aksel-icons": "7.x",

--- a/packages/familie-form-elements/package.json
+++ b/packages/familie-form-elements/package.json
@@ -13,10 +13,11 @@
         "url": "https://github.com/navikt/familie-felles-frontend"
     },
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 src/**/*.less dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "classnames": "^2.5.1",
@@ -26,7 +27,8 @@
         "@navikt/ds-css": "7.x",
         "@navikt/ds-react": "7.x",
         "@navikt/ds-tokens": "7.x",
-        "styled-components": "^6.x"
+        "styled-components": "^6.x",
+        "tsc-alias": "^1.8.16"
     },
     "peerDependencies": {
         "@navikt/ds-css": "7.x",

--- a/packages/familie-header/package.json
+++ b/packages/familie-header/package.json
@@ -18,9 +18,10 @@
         "url": "https://github.com/navikt/familie-felles-frontend"
     },
     "scripts": {
-        "build": "yarn run clean && yarn run tsc",
+        "build": "yarn run clean && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "@navikt/familie-ikoner": "^9.1.1",
@@ -31,7 +32,8 @@
         "@navikt/aksel-icons": "7.x",
         "@navikt/ds-css": "7.x",
         "@navikt/ds-react": "7.x",
-        "styled-components": "6.x"
+        "styled-components": "6.x",
+        "tsc-alias": "^1.8.16"
     },
     "peerDependencies": {
         "@navikt/aksel-icons": "7.x",

--- a/packages/familie-http/package.json
+++ b/packages/familie-http/package.json
@@ -19,10 +19,11 @@
         "dist"
     ],
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 src/**/*.less dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "@navikt/familie-typer": "^8.0.3",
@@ -31,5 +32,8 @@
     "peerDependencies": {
         "axios": "1.x",
         "react": "18.x || 19.x"
+    },
+    "devDependencies": {
+        "tsc-alias": "^1.8.16"
     }
 }

--- a/packages/familie-ikoner/package.json
+++ b/packages/familie-ikoner/package.json
@@ -18,15 +18,19 @@
         "dist"
     ],
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 src/**/*.less dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "@navikt/familie-typer": "^8.0.3"
     },
     "peerDependencies": {
         "react": "18.x || 19.x"
+    },
+    "devDependencies": {
+        "tsc-alias": "^1.8.16"
     }
 }

--- a/packages/familie-logging/package.json
+++ b/packages/familie-logging/package.json
@@ -19,12 +19,16 @@
         "dist"
     ],
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 src/**/*.less dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "winston": "^3.17.0"
+    },
+    "devDependencies": {
+        "tsc-alias": "^1.8.16"
     }
 }

--- a/packages/familie-skjema/package.json
+++ b/packages/familie-skjema/package.json
@@ -19,10 +19,11 @@
         "dist"
     ],
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc  && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 src/**/*.less dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "@navikt/familie-http": "^8.0.0",
@@ -32,7 +33,8 @@
         "hashids": "^2.3.0"
     },
     "devDependencies": {
-        "@navikt/familie-form-elements": "^21.0.4"
+        "@navikt/familie-form-elements": "^21.0.4",
+        "tsc-alias": "^1.8.16"
     },
     "peerDependencies": {
         "react": "18.x || 19.x"

--- a/packages/familie-tidslinje/package.json
+++ b/packages/familie-tidslinje/package.json
@@ -18,10 +18,11 @@
         "url": "https://github.com/navikt/familie-felles-frontend"
     },
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 src/**/*.less dist",
         "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json",
         "test": "jest"
     },
     "dependencies": {
@@ -43,6 +44,7 @@
         "@navikt/ds-tokens": "7.x",
         "@types/jest": "^29.5.12",
         "dayjs": "1.x",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "tsc-alias": "^1.8.16"
     }
 }

--- a/packages/familie-typer/package.json
+++ b/packages/familie-typer/package.json
@@ -19,9 +19,13 @@
         "dist"
     ],
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 src/**/*.less dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
+    },
+    "devDependencies": {
+        "tsc-alias": "^1.8.16"
     }
 }

--- a/packages/familie-typer/tsconfig.json
+++ b/packages/familie-typer/tsconfig.json
@@ -4,9 +4,5 @@
     "compilerOptions": {
         "outDir": "./dist",
         "module": "es6",
-    },
-    "tsc-alias": {
-    "resolveFullPaths": true,
-    "verbose": false
-  }
+    }
 }

--- a/packages/familie-typer/tsconfig.json
+++ b/packages/familie-typer/tsconfig.json
@@ -4,5 +4,9 @@
     "compilerOptions": {
         "outDir": "./dist",
         "module": "es6",
-    }
+    },
+    "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  }
 }

--- a/packages/familie-visittkort/package.json
+++ b/packages/familie-visittkort/package.json
@@ -18,10 +18,11 @@
         "dist"
     ],
     "scripts": {
-        "build": "yarn run clean && yarn run copy-less && yarn run tsc",
+        "build": "yarn run clean && yarn run copy-less && yarn run tsc && yarn run tsc-alias",
         "clean": "rm -rf ./dist",
         "copy-less": "copyfiles -u 1 src/**/*.less dist",
-        "tsc": "tsc -p tsconfig.json"
+        "tsc": "tsc -p tsconfig.json",
+        "tsc-alias": "tsc-alias -p tsconfig.json"
     },
     "dependencies": {
         "@navikt/familie-ikoner": "^9.1.1",
@@ -33,7 +34,8 @@
         "@navikt/ds-css": "7.x",
         "@navikt/ds-react": "7.x",
         "@navikt/ds-tokens": "7.x",
-        "styled-components": "^6.x"
+        "styled-components": "^6.x",
+        "tsc-alias": "^1.8.16"
     },
     "peerDependencies": {
         "@navikt/ds-css": "7.x",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,5 +22,9 @@
     "jsx": "react",
     "esModuleInterop": true,
     "skipLibCheck": true
-  }
+  },
+    "tsc-alias": {
+        "resolveFullPaths": true,
+        "verbose": false
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4918,6 +4918,11 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
+commander@^9.0.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
+
 commander@~12.1.0:
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
@@ -7312,6 +7317,13 @@ get-symbol-description@^1.1.0:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
 
+get-tsconfig@^4.10.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.10.1.tgz#d34c1c01f47d65a606c37aa7a177bc3e56ab4b2e"
+  integrity sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
+
 git-raw-commits@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-3.0.0.tgz#5432f053a9744f67e8db03dbc48add81252cfdeb"
@@ -7498,7 +7510,7 @@ globalthis@^1.0.4:
     define-properties "^1.2.1"
     gopd "^1.0.1"
 
-globby@11.1.0:
+globby@11.1.0, globby@^11.0.4:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -10385,6 +10397,11 @@ mute-stream@^1.0.0, mute-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
 
+mylas@^2.1.9:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/mylas/-/mylas-2.1.13.tgz#1e23b37d58fdcc76e15d8a5ed23f9ae9fc0cbdf4"
+  integrity sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==
+
 nanoid@^3.3.6, nanoid@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
@@ -11374,6 +11391,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+plimit-lit@^1.2.6:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/plimit-lit/-/plimit-lit-1.6.1.tgz#a34594671b31ee8e93c72d505dfb6852eb72374a"
+  integrity sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==
+  dependencies:
+    queue-lit "^1.5.1"
+
 polished@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/polished/-/polished-4.2.2.tgz#2529bb7c3198945373c52e34618c8fe7b1aa84d1"
@@ -11638,6 +11662,11 @@ qs@6.13.0, qs@^6.11.2:
   integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
   dependencies:
     side-channel "^1.0.6"
+
+queue-lit@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/queue-lit/-/queue-lit-1.5.2.tgz#83c24d4f4764802377b05a6e5c73017caf3f8747"
+  integrity sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -12133,6 +12162,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
 resolve.exports@2.0.3:
   version "2.0.3"
@@ -13319,6 +13353,19 @@ ts-dedent@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
+
+tsc-alias@^1.8.16:
+  version "1.8.16"
+  resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.8.16.tgz#dbc74e797071801c7284f1a478259de920f852d4"
+  integrity sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==
+  dependencies:
+    chokidar "^3.5.3"
+    commander "^9.0.0"
+    get-tsconfig "^4.10.0"
+    globby "^11.0.4"
+    mylas "^2.1.9"
+    normalize-path "^3.0.0"
+    plimit-lit "^1.2.6"
 
 tsconfig-paths@^4.1.2, tsconfig-paths@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Siden Node 18 er [filendelser i import-statements nå obligatoriske for ES-moduler](https://nodejs.org/dist/latest-v18.x/docs/api/esm.html#esm_mandatory_file_extensions). Denne pakken fikser slik at vi får riktige filendelser i de byggede filene våre.

Endringen er rett og slett slik (eksempel fra familie-typer sin byggede index.js):
````
export * from './person.js';
export * from './oppgave.js';
export * from './saksbehandler.js';
export * from './ressurs.js';
export * from './journalføring.js';
//# sourceMappingURL=index.js.map
````

I stedet for den gamle koden:
````
export * from './person';
export * from './oppgave';
export * from './saksbehandler';
export * from './ressurs';
export * from './journalføring';
//# sourceMappingURL=index.js.map
````

Jeg fant problemet når jeg prøvde å sette opp vitest i stedet for jest. Disse pakkene feilet på importen. Siden vi ønsker å bytte til vitest fra jest må disse endringene være på plass først.

Dette er også måten aksel har løst samme problemstilling på: https://github.com/navikt/aksel/blob/636c1ad49b8afde54b0a1105fecdc6d47f333522/%40navikt/core/react/tsconfig.esm.json#L9