### PR TITLE
feat(header - synlig skille mellom dev og prod): ønsker å gjøre det m…

### DIFF
--- a/packages/familie-header/src/header/Header.tsx
+++ b/packages/familie-header/src/header/Header.tsx
@@ -3,6 +3,8 @@ import '@navikt/ds-css';
 import { ActionMenu, InternalHeader as NavHeader } from '@navikt/ds-react';
 import { MenuGridIcon, WrenchIcon } from '@navikt/aksel-icons';
 import { EksternLinkIkon } from '@navikt/familie-ikoner';
+import clsx from 'clsx';
+import './header.css';
 
 export interface Brukerinfo {
     navn: string;
@@ -40,6 +42,7 @@ export interface HeaderProps {
     brukerPopoverItems?: PopoverItem[];
     eksterneLenker: PopoverItem[];
     tittelOnClick?: () => void;
+    erDev?: boolean;
 }
 
 interface BrukerProps {
@@ -175,6 +178,7 @@ export const Header = ({
     brukerPopoverItems,
     eksterneLenker = [],
     tittelOnClick,
+    erDev,
 }: HeaderProps) => {
     const skalViseLabelOgIkon = (type: LenkeType | undefined) =>
         type === LenkeType.EKSTERN || type === LenkeType.ARBEIDSVERKTØY;
@@ -183,7 +187,7 @@ export const Header = ({
     );
 
     return (
-        <NavHeader data-theme={''}>
+        <NavHeader data-theme={''} className={clsx({ devHeader: erDev })}>
             {!tittelOnClick && <NavHeader.Title href={tittelHref}>{tittel}</NavHeader.Title>}
             {tittelOnClick && (
                 <NavHeader.Title onClick={tittelOnClick} style={{ cursor: 'pointer' }}>

--- a/packages/familie-header/src/header/header.css
+++ b/packages/familie-header/src/header/header.css
@@ -1,0 +1,9 @@
+.devHeader {
+    background: repeating-linear-gradient(
+        -45deg,
+        #4d4d00,
+        #4d4d00 20px,
+        var(--a-gray-900) 20px,
+        var(--a-gray-900) 40px
+    );
+}


### PR DESCRIPTION
…er synlig når man er i dev prod

Ble inspirert av noen andre sin løsning. Legger til optional prop for å gjøre det enklere å se om man er i dev eller prod. Dev vises med et mønster på header.

![image](https://github.com/user-attachments/assets/c33f45ac-9e92-4419-b34b-31f758cbc668)
