### PR TITLE
Lagre sesjon eksplisitt før OIDC-redirect i authenticateAzure

### DIFF
--- a/packages/familie-backend/src/auth/authenticate.ts
+++ b/packages/familie-backend/src/auth/authenticate.ts
@@ -32,7 +32,7 @@ export const authenticateAzure = (req: Request, res: Response, next: NextFunctio
                 successRedirect,
             })(req, res, next);
         } catch (err) {
-            throw new Error(`Error during authentication: ${err}`);
+            throw new Error(`Autentiseringsfeil: ${err}`);
         }
     });
 };

--- a/packages/familie-backend/src/auth/authenticate.ts
+++ b/packages/familie-backend/src/auth/authenticate.ts
@@ -22,14 +22,19 @@ export const authenticateAzure = (req: Request, res: Response, next: NextFunctio
     }
 
     req.session.redirectUrl = successRedirect;
-    try {
-        passport.authenticate('azureOidc', {
-            failureRedirect: '/error',
-            successRedirect,
-        })(req, res, next);
-    } catch (err) {
-        throw new Error(`Error during authentication: ${err}`);
-    }
+    req.session.save(err => {
+        if (err) {
+            return next(err);
+        }
+        try {
+            passport.authenticate('azureOidc', {
+                failureRedirect: '/error',
+                successRedirect,
+            })(req, res, next);
+        } catch (err) {
+            throw new Error(`Error during authentication: ${err}`);
+        }
+    });
 };
 
 export const authenticateAzureCallback = () => {


### PR DESCRIPTION
Ved innlogging via Azure AD setter openid-client OIDC-state (nonce, state,  code_verifier) i sesjonen og sender umiddelbart en 302-redirect til Microsoft. express-session lagrer sesjonen som en del av res.end()-hook-mekanismen, men sender responsen uansett dersom Redis-skriving feiler, uten at kallet som startet flyten får beskjed.
 
Resultat: bruker sendes til Microsoft og tilbake, men sesjonen er aldri lagret. openid-client finner ikke OIDC-state i callback og krasjer med: `did not find expected authorization request details in session, req.session["oidc:login.microsoftonline.com"] is undefined`
 
Fiksen kaller req.session.save() eksplisitt før passport.authenticate() kjøres. Hvis Redis feiler, propageres feilen via next(err) og OIDC-flyten starter aldri. Bruker får en eksplisitt feil i /login fremfor en kryptisk feil etter retur fra Microsoft.
 
Normal flyt er uendret, men medfører én ekstra Redis-skriving per innlogging